### PR TITLE
feat(auth): wire login/logout/register views (#10)

### DIFF
--- a/coreRelback/templates/base.html
+++ b/coreRelback/templates/base.html
@@ -66,7 +66,7 @@
                     <div class="md-dropdown">
                         <button class="md-dropdown-trigger" id="userDropdown">
                             <i class="material-icons">account_circle</i>
-                            <span class="md-nav-text">User</span>
+                            <span class="md-nav-text">{{ request.user.username }}</span>
                             <i class="material-icons md-dropdown-arrow">keyboard_arrow_down</i>
                         </button>
                         <div class="md-dropdown-menu" id="userMenu">
@@ -75,10 +75,13 @@
                                 <span>Settings</span>
                             </a>
                             <div class="md-dropdown-divider"></div>
-                            <a class="md-dropdown-item" href="#">
-                                <i class="material-icons">logout</i>
-                                <span>Sign Out</span>
-                            </a>
+                            <form method="post" action="{% url 'coreRelback:logout' %}" style="margin:0">
+                                {% csrf_token %}
+                                <button type="submit" class="md-dropdown-item" style="background:none;border:none;width:100%;text-align:left;cursor:pointer;">
+                                    <i class="material-icons">logout</i>
+                                    <span>Sign Out</span>
+                                </button>
+                            </form>
                         </div>
                     </div>
                 </div>

--- a/coreRelback/tests.py
+++ b/coreRelback/tests.py
@@ -110,3 +110,71 @@ class AuthenticatedTemplateTests(TestCase):
         response = self.client.get(reverse("coreRelback:creators"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "creators.html")
+
+
+class LoginViewTests(TestCase):
+    """Tests for the /login/ endpoint wired to Django's built-in LoginView."""
+
+    def setUp(self):
+        from coreRelback.models import RelbackUser
+        ru = RelbackUser(username="logintest", status=1, email="login@test.com")
+        ru.set_password("pass1234!")
+        ru.save()
+
+    def test_login_page_renders(self):
+        response = self.client.get(reverse("coreRelback:login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "auth/login.html")
+
+    def test_valid_credentials_redirect_to_home(self):
+        response = self.client.post(
+            reverse("coreRelback:login"),
+            {"username": "logintest", "password": "pass1234!"},
+        )
+        # Should redirect to LOGIN_REDIRECT_URL = '/'
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/")
+
+    def test_invalid_credentials_show_form_again(self):
+        response = self.client.post(
+            reverse("coreRelback:login"),
+            {"username": "logintest", "password": "wrongpassword"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "auth/login.html")
+
+
+class LogoutRegisterTests(TestCase):
+    """Tests for logout and register endpoints."""
+
+    def setUp(self):
+        self.django_user = User.objects.create_user(
+            username="logouttest", password="pass1234!"
+        )
+
+    def test_logout_redirects_to_login(self):
+        self.client.force_login(self.django_user)
+        response = self.client.post(reverse("coreRelback:logout"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response["Location"])
+
+    def test_register_page_renders(self):
+        response = self.client.get(reverse("coreRelback:register"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "auth/register.html")
+
+    def test_register_creates_account_and_redirects(self):
+        response = self.client.post(
+            reverse("coreRelback:register"),
+            {
+                "username": "newuser",
+                "name": "New User",
+                "email": "new@test.com",
+                "password1": "securepass99!",
+                "password2": "securepass99!",
+            },
+        )
+        from coreRelback.models import RelbackUser
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response["Location"])
+        self.assertTrue(RelbackUser.objects.filter(username="newuser").exists())

--- a/coreRelback/urls.py
+++ b/coreRelback/urls.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import path
 from coreRelback.views import (
-    index, creators,
+    index, creators, register_view,
     ClientListView, ClientCreateView, ClientUpdateView, ClientDeleteView,
     HostListView, HostCreateView, HostUpdateView, HostDeleteView,
     DatabaseListView, DatabaseCreateView, DatabaseUpdateView, DatabaseDeleteView,
@@ -53,4 +54,9 @@ urlpatterns = [
     path("reports/", report_read, name="report-read"),
     path("reports/read-log-detail/<int:idPolicy>/<int:dbKey>/<int:sessionKey>/", report_read_log_detail, name="report-read-log-detail"),
     path("reports/refresh-schedule/", report_refresh_schedule, name="report-refresh-schedule"),
+
+    # Auth endpoints
+    path("login/", auth_views.LoginView.as_view(template_name='auth/login.html'), name="login"),
+    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("register/", register_view, name="register"),
 ]

--- a/coreRelback/views.py
+++ b/coreRelback/views.py
@@ -610,3 +610,27 @@ def report_read(request):
 def report_read_log_detail(request, idPolicy, dbKey, sessionKey):
     context = {"idPolicy": idPolicy, "dbKey": dbKey, "sessionKey": sessionKey}
     return render(request, "reportsReadLog.html", context)
+
+
+# ---------------------------
+# AUTH VIEWS
+# ---------------------------
+
+def register_view(request):
+    """Public view to create a new RelbackUser account.
+
+    Uses RelbackUserCreationForm (forms.py) which handles password hashing
+    and sets status=1 (active) by default.
+    After successful registration the user is redirected to the login page.
+    """
+    from coreRelback.forms import RelbackUserCreationForm
+
+    if request.method == 'POST':
+        form = RelbackUserCreationForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Account created successfully. Please sign in.")
+            return redirect('coreRelback:login')
+    else:
+        form = RelbackUserCreationForm()
+    return render(request, 'auth/register.html', {'form': form})


### PR DESCRIPTION
## Summary
Completes the authentication flow. After PR #5 added `LoginRequiredMixin` to all views, users were being redirected to `/login/` which returned a **404** — no URL was registered.

## Changes
| File | Change |
|---|---|
| `coreRelback/urls.py` | Added `login/`, `logout/`, `register/` routes |
| `coreRelback/views.py` | Added `register_view` (uses existing `RelbackUserCreationForm`) |
| `coreRelback/templates/base.html` | Sign Out → POST form (Django 5+ requires POST); navbar shows `{{ request.user.username }}` |
| `coreRelback/tests.py` | +6 tests: `LoginViewTests` + `LogoutRegisterTests` |

## Auth flow
- `GET /login/` → renders `auth/login.html` via Django's `LoginView`
- `POST /login/` with valid credentials → redirect to `/`
- `POST /logout/` → redirect to `/login/`
- `GET /register/` → renders `auth/register.html`
- `POST /register/` with valid data → creates `RelbackUser` → redirect to `/login/`
- `RelbackUserBackend` handles credential validation (existing, unchanged)

## Test Results
- Gate 1: `manage.py check` — ✅ 0 issues
- Gate 2: Domain tests (21) — ✅ OK
- Gate 3: Integration tests (20) — ✅ OK (3.213s)
  - `LoginViewTests` (3): login page + valid/invalid credentials
  - `LogoutRegisterTests` (3): logout redirect + register page + register creates account

Closes #10