### PR TITLE
[UI] Phase 4.3 — CRUD list views: DaisyUI stats, table, buttons

### DIFF
--- a/coreRelback/templates/clients.html
+++ b/coreRelback/templates/clients.html
@@ -16,8 +16,8 @@
                         <p class="page-subtitle">Manage your backup clients and organizations</p>
                     </div>
                 </div>
-                <button type="button" class="md-btn md-btn-primary page-actions" data-modal-target="#addClientModal">
-                    <i class="material-icons md-me-1">add</i>
+                <button type="button" class="btn btn-primary" data-modal-target="#addClientModal">
+                    <i class="material-icons" style="font-size: 18px;">add</i>
                     Add Client
                 </button>
             </div>
@@ -25,24 +25,20 @@
     </div>
 
     <!-- Stats Cards -->
-    <div class="md-grid md-grid-cols-4 md-mb-5">
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ clients.count }}</h2>
-                    <p class="stats-subtitle">Total Clients</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">business</i>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-5">
+        <div class="stat">
+            <div class="stat-figure text-primary">
+                <i class="material-icons-round" style="font-size: 2.5rem;">business</i>
             </div>
+            <div class="stat-title">Total Clients</div>
+            <div class="stat-value stats-title">{{ clients.count }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ clients|length }}</h2>
-                    <p class="stats-subtitle">Active Clients</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">verified</i>
+        <div class="stat">
+            <div class="stat-figure text-success">
+                <i class="material-icons-round" style="font-size: 2.5rem;">verified</i>
             </div>
+            <div class="stat-title">Active Clients</div>
+            <div class="stat-value text-success stats-title">{{ clients|length }}</div>
         </div>
     </div>
 
@@ -54,8 +50,8 @@
                     <input type="text" class="md-input" id="searchClients" placeholder="Search clients..." autocomplete="off">
                     <div class="autocomplete-list" id="autocompleteList"></div>
                 </div>
-                <button class="md-btn md-btn-text clean-btn" id="cleanBtn">
-                    <i class="material-icons md-me-1">clear</i>
+                <button class="btn btn-ghost btn-sm clean-btn" id="cleanBtn">
+                    <i class="material-icons" style="font-size: 18px;">clear</i>
                     Clean
                 </button>
             </div>
@@ -66,8 +62,8 @@
     <div class="md-grid md-grid-cols-1">
         <div class="md-card md-card-decorated">
             {% if clients %}
-                <div class="md-table-responsive">
-                    <table class="md-table">
+                <div class="overflow-x-auto">
+                    <table class="table table-xs table-zebra w-full">
                         <thead>
                             <tr>
                                 <th class="oracle-info-gradient">
@@ -137,8 +133,8 @@
                     <i class="material-icons empty-state-icon">business</i>
                     <h4 class="empty-state-title">No clients found</h4>
                     <p class="empty-state-description">Get started by adding your first client</p>
-                    <a href="{% url 'coreRelback:client-create' %}" class="md-btn md-btn-primary empty-state-action">
-                        <i class="material-icons md-me-1">add</i>
+                    <a href="{% url 'coreRelback:client-create' %}" class="btn btn-primary">
+                        <i class="material-icons" style="font-size: 18px;">add</i>
                         Add First Client
                     </a>
                 </div>
@@ -148,7 +144,7 @@
 </div>
 
 <!-- Floating Action Button -->
-<button class="md-fab" id="addClientFab" title="Add Client">
+<button class="btn btn-circle btn-primary btn-lg fixed bottom-6 right-6 shadow-lg z-50" id="addClientFab" title="Add Client">
     <i class="material-icons">add</i>
 </button>
 

--- a/coreRelback/templates/databases.html
+++ b/coreRelback/templates/databases.html
@@ -16,8 +16,8 @@
                         <p class="page-subtitle">Manage your database backup configurations</p>
                     </div>
                 </div>
-                <button type="button" class="md-btn md-btn-primary page-actions" data-modal-target="#addDatabaseModal">
-                    <i class="material-icons md-me-1">add</i>
+                <button type="button" class="btn btn-primary" data-modal-target="#addDatabaseModal">
+                    <i class="material-icons" style="font-size: 18px;">add</i>
                     Add Database
                 </button>
             </div>
@@ -25,42 +25,34 @@
     </div>
 
     <!-- Stats Cards -->
-    <div class="md-grid md-grid-cols-4 md-mb-5">
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ databases.count }}</h2>
-                    <p class="stats-subtitle">Total Databases</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">storage</i>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-5">
+        <div class="stat">
+            <div class="stat-figure text-primary">
+                <i class="material-icons-round" style="font-size: 2.5rem;">storage</i>
             </div>
+            <div class="stat-title">Total Databases</div>
+            <div class="stat-value stats-title">{{ databases.count }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ active_databases|default:0 }}</h2>
-                    <p class="stats-subtitle">Active Databases</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">check_circle</i>
+        <div class="stat">
+            <div class="stat-figure text-success">
+                <i class="material-icons-round" style="font-size: 2.5rem;">check_circle</i>
             </div>
+            <div class="stat-title">Active Databases</div>
+            <div class="stat-value text-success stats-title">{{ active_databases|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ oracle_databases|default:0 }}</h2>
-                    <p class="stats-subtitle">Oracle Databases</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">account_tree</i>
+        <div class="stat">
+            <div class="stat-figure text-info">
+                <i class="material-icons-round" style="font-size: 2.5rem;">account_tree</i>
             </div>
+            <div class="stat-title">Oracle Databases</div>
+            <div class="stat-value stats-title">{{ oracle_databases|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ backed_up_today|default:0 }}</h2>
-                    <p class="stats-subtitle">Backed Up Today</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">backup</i>
+        <div class="stat">
+            <div class="stat-figure text-warning">
+                <i class="material-icons-round" style="font-size: 2.5rem;">backup</i>
             </div>
+            <div class="stat-title">Backed Up Today</div>
+            <div class="stat-value stats-title">{{ backed_up_today|default:0 }}</div>
         </div>
     </div>
 
@@ -72,8 +64,8 @@
                     <input type="text" class="md-input" id="searchDatabases" placeholder="Search databases..." autocomplete="off">
                     <div class="autocomplete-list" id="autocompleteList"></div>
                 </div>
-                <button class="md-btn md-btn-text clean-btn" id="cleanBtn">
-                    <i class="material-icons md-me-1">clear</i>
+                <button class="btn btn-ghost btn-sm clean-btn" id="cleanBtn">
+                    <i class="material-icons" style="font-size: 18px;">clear</i>
                     Clean
                 </button>
             </div>
@@ -83,8 +75,8 @@
     <div class="md-grid md-grid-cols-1">
         <div class="md-card md-card-decorated">
             {% if databases %}
-                <div class="md-table-responsive">
-                    <table class="md-table">
+                <div class="overflow-x-auto">
+                    <table class="table table-xs table-zebra w-full">
                         <thead>
                             <tr>
                                 <th class="oracle-info-gradient">
@@ -237,8 +229,8 @@
                                     <i class="material-icons md-mb-3" style="font-size: 64px; color: #C74634; opacity: 0.6;">storage</i>
                                     <h5 class="md-text-muted">No databases found</h5>
                                     <p class="md-text-muted">Start by adding your first database configuration.</p>
-                                    <a href="{% url 'coreRelback:database-create' %}" class="md-btn md-btn-primary">
-                                        <i class="material-icons md-me-1">add</i>
+                                    <a href="{% url 'coreRelback:database-create' %}" class="btn btn-primary">
+                                        <i class="material-icons" style="font-size: 18px;">add</i>
                                         Add First Database
                                     </a>
                                 </div>
@@ -254,7 +246,7 @@
 </div>
 
 <!-- Floating Action Button -->
-<button class="md-fab" id="addDatabaseFab" title="Add Database">
+<button class="btn btn-circle btn-primary btn-lg fixed bottom-6 right-6 shadow-lg z-50" id="addDatabaseFab" title="Add Database">
     <i class="material-icons">add</i>
 </button>
 

--- a/coreRelback/templates/hosts.html
+++ b/coreRelback/templates/hosts.html
@@ -16,8 +16,8 @@
                         <p class="page-subtitle">Manage your backup host servers</p>
                     </div>
                 </div>
-                <button type="button" class="md-btn md-btn-primary page-actions" data-modal-target="#addHostModal">
-                    <i class="material-icons md-me-1">add</i>
+                <button type="button" class="btn btn-primary" data-modal-target="#addHostModal">
+                    <i class="material-icons" style="font-size: 18px;">add</i>
                     Add Host
                 </button>
             </div>
@@ -25,42 +25,34 @@
     </div>
 
     <!-- Stats Cards -->
-    <div class="md-grid md-grid-cols-4 md-mb-5">
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ total_hosts }}</h2>
-                    <p class="stats-subtitle">Total Hosts</p>
-                </div>
-                <i class="material-icons stats-card-icon">dns</i>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-5">
+        <div class="stat">
+            <div class="stat-figure text-primary">
+                <i class="material-icons" style="font-size: 2.5rem;">dns</i>
             </div>
+            <div class="stat-title">Total Hosts</div>
+            <div class="stat-value stats-title">{{ total_hosts }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ active_hosts|default:0 }}</h2>
-                    <p class="stats-subtitle">Active Hosts</p>
-                </div>
-                <i class="material-icons stats-card-icon">check_circle</i>
+        <div class="stat">
+            <div class="stat-figure text-success">
+                <i class="material-icons" style="font-size: 2.5rem;">check_circle</i>
             </div>
+            <div class="stat-title">Active Hosts</div>
+            <div class="stat-value text-success stats-title">{{ active_hosts|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ total_clients|default:0 }}</h2>
-                    <p class="stats-subtitle">Clients</p>
-                </div>
-                <i class="material-icons stats-card-icon">business</i>
+        <div class="stat">
+            <div class="stat-figure text-info">
+                <i class="material-icons" style="font-size: 2.5rem;">business</i>
             </div>
+            <div class="stat-title">Clients</div>
+            <div class="stat-value stats-title">{{ total_clients|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ total_databases|default:0 }}</h2>
-                    <p class="stats-subtitle">Databases</p>
-                </div>
-                <i class="material-icons stats-card-icon">storage</i>
+        <div class="stat">
+            <div class="stat-figure text-warning">
+                <i class="material-icons" style="font-size: 2.5rem;">storage</i>
             </div>
+            <div class="stat-title">Databases</div>
+            <div class="stat-value stats-title">{{ total_databases|default:0 }}</div>
         </div>
     </div>
 
@@ -72,8 +64,8 @@
                     <input type="text" class="md-input" id="searchHosts" placeholder="Search hosts..." autocomplete="off">
                     <div class="autocomplete-list" id="autocompleteList"></div>
                 </div>
-                <button class="md-btn md-btn-text clean-btn" id="cleanBtn">
-                    <i class="material-icons md-me-1">clear</i>
+                <button class="btn btn-ghost btn-sm clean-btn" id="cleanBtn">
+                    <i class="material-icons" style="font-size: 18px;">clear</i>
                     Clean
                 </button>
             </div>
@@ -84,8 +76,8 @@
     <div class="md-grid md-grid-cols-1">
         <div class="md-card md-card-decorated">
             {% if hosts %}
-                <div class="md-table-responsive">
-                    <table class="md-table">
+                <div class="overflow-x-auto">
+                    <table class="table table-xs table-zebra w-full">
                         <thead>
                             <tr>
                                 <th class="oracle-info-gradient">
@@ -173,8 +165,8 @@
                     <i class="material-icons empty-state-icon">dns</i>
                     <h4 class="empty-state-title">No hosts found</h4>
                     <p class="empty-state-description">Get started by adding your first host</p>
-                    <a href="{% url 'coreRelback:host-create' %}" class="md-btn md-btn-primary empty-state-action">
-                        <i class="material-icons md-me-1">add</i>
+                    <a href="{% url 'coreRelback:host-create' %}" class="btn btn-primary">
+                        <i class="material-icons" style="font-size: 18px;">add</i>
                         Add First Host
                     </a>
                 </div>
@@ -184,7 +176,7 @@
 </div>
 
 <!-- Floating Action Button -->
-<button class="md-fab" id="addHostFab" title="Add Host">
+<button class="btn btn-circle btn-primary btn-lg fixed bottom-6 right-6 shadow-lg z-50" id="addHostFab" title="Add Host">
     <i class="material-icons">add</i>
 </button>
 

--- a/coreRelback/templates/policies.html
+++ b/coreRelback/templates/policies.html
@@ -16,8 +16,8 @@
                         <p class="page-subtitle">Manage backup schedules and retention policies</p>
                     </div>
                 </div>
-                <button type="button" class="md-btn md-btn-primary page-actions" data-modal-target="#addPolicyModal">
-                    <i class="material-icons md-me-1">add</i>
+                <button type="button" class="btn btn-primary" data-modal-target="#addPolicyModal">
+                    <i class="material-icons" style="font-size: 18px;">add</i>
                     Create Policy
                 </button>
             </div>
@@ -25,42 +25,34 @@
     </div>
 
     <!-- Stats Cards -->
-    <div class="md-grid md-grid-cols-4 md-mb-5">
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ total_policies }}</h2>
-                    <p class="stats-subtitle">Total Policies</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">security</i>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-5">
+        <div class="stat">
+            <div class="stat-figure text-primary">
+                <i class="material-icons-round" style="font-size: 2.5rem;">security</i>
             </div>
+            <div class="stat-title">Total Policies</div>
+            <div class="stat-value stats-title">{{ total_policies }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ active_policies|default:0 }}</h2>
-                    <p class="stats-subtitle">Active Policies</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">play_circle</i>
+        <div class="stat">
+            <div class="stat-figure text-success">
+                <i class="material-icons-round" style="font-size: 2.5rem;">play_circle</i>
             </div>
+            <div class="stat-title">Active Policies</div>
+            <div class="stat-value text-success stats-title">{{ active_policies|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ inactive_policies|default:0 }}</h2>
-                    <p class="stats-subtitle">Inactive Policies</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">pause_circle</i>
+        <div class="stat">
+            <div class="stat-figure text-error">
+                <i class="material-icons-round" style="font-size: 2.5rem;">pause_circle</i>
             </div>
+            <div class="stat-title">Inactive Policies</div>
+            <div class="stat-value text-error stats-title">{{ inactive_policies|default:0 }}</div>
         </div>
-        <div class="md-card oracle-info-gradient stats-card-content">
-            <div class="md-flex md-items-center md-justify-between">
-                <div>
-                    <h2 class="stats-title">{{ scheduled_policies|default:0 }}</h2>
-                    <p class="stats-subtitle">Scheduled Policies</p>
-                </div>
-                <i class="material-icons-round stats-card-icon">schedule</i>
+        <div class="stat">
+            <div class="stat-figure text-info">
+                <i class="material-icons-round" style="font-size: 2.5rem;">schedule</i>
             </div>
+            <div class="stat-title">Scheduled Policies</div>
+            <div class="stat-value stats-title">{{ scheduled_policies|default:0 }}</div>
         </div>
     </div>
 
@@ -73,8 +65,8 @@
                     <i class="material-icons search-icon">search</i>
                     <div class="autocomplete-list" id="autocompleteList"></div>
                 </div>
-                <button class="md-btn md-btn-text clean-btn" id="cleanBtn">
-                    <i class="material-icons">clear</i>
+                <button class="btn btn-ghost btn-sm clean-btn" id="cleanBtn">
+                    <i class="material-icons" style="font-size: 18px;">clear</i>
                     Clean
                 </button>
             </div>
@@ -83,8 +75,8 @@
     <div class="md-grid md-grid-cols-1">
         <div class="md-card md-card-decorated">
             {% if policies %}
-                <div class="md-table-responsive">
-                    <table class="md-table md-mb-0" id="policiesTable">
+                <div class="overflow-x-auto">
+                    <table class="table table-xs table-zebra w-full" id="policiesTable">
                         <thead>
                             <tr>
                                 <th class="oracle-info-gradient">
@@ -262,7 +254,7 @@
 </div>
 
 <!-- Floating Action Button -->
-<button class="md-fab" id="addPolicyFab" title="Add Policy">
+<button class="btn btn-circle btn-primary btn-lg fixed bottom-6 right-6 shadow-lg z-50" id="addPolicyFab" title="Add Policy">
     <i class="material-icons">add</i>
 </button>
 


### PR DESCRIPTION
## Summary
Phase 4.3 of the Tailwind/DaisyUI migration roadmap — CRUD list views.

Closes #26

## Files changed
- `clients.html` — 2-stat row + table + buttons + FAB
- `hosts.html` — 4-stat row + table + buttons + FAB
- `databases.html` — 4-stat row + table + buttons + FAB
- `policies.html` — 4-stat row + table + buttons + FAB

## Changes per template
| Component | Before | After |
|---|---|---|
| Stats row | `md-grid md-grid-cols-4` + `md-card oracle-info-gradient` | DaisyUI `stats stats-vertical lg:stats-horizontal` |
| Page header button | `md-btn md-btn-primary page-actions` | `btn btn-primary` |
| Search clean button | `md-btn md-btn-text clean-btn` | `btn btn-ghost btn-sm clean-btn` |
| Table container | `md-table-responsive` | `overflow-x-auto` |
| Table | `md-table` / `md-table md-mb-0` | `table table-xs table-zebra w-full` |
| Empty state button | `md-btn md-btn-primary empty-state-action` / `md-btn md-btn-primary` | `btn btn-primary` |
| FAB | `md-fab` | `btn btn-circle btn-primary btn-lg fixed bottom-6 right-6 shadow-lg z-50` |

## Sensors
- ✅ Sensor 1: `manage.py check --settings=settings_dev` — 0 issues
- ✅ Sensor 2: 29 domain tests — OK
- ✅ Sensor 3: Tailwind build — Done in 1460ms