### PR TITLE
[oracle] feat: implement report_read_log_detail with RC_RMAN_OUTPUT (#37)

### DIFF
--- a/coreRelback/domain/entities.py
+++ b/coreRelback/domain/entities.py
@@ -146,6 +146,14 @@ class BackupJobResult:
 
 
 @dataclass
+class BackupLogEntry:
+    """One line of RMAN output from RC_RMAN_OUTPUT (read-only catalog entity)."""
+    recid: int
+    output: str
+    stamp: Optional[int] = None
+
+
+@dataclass
 class DashboardStats:
     """Aggregated stats for the index page — computed, not stored."""
     clients_count: int

--- a/coreRelback/gateways/interfaces.py
+++ b/coreRelback/gateways/interfaces.py
@@ -10,12 +10,13 @@ from datetime import date, datetime
 from typing import List, Optional
 
 from coreRelback.domain.entities import (
-    ClientEntity,
-    HostEntity,
-    DatabaseEntity,
-    BackupPolicyEntity,
-    ScheduleEntry,
     BackupJobResult,
+    BackupLogEntry,
+    BackupPolicyEntity,
+    ClientEntity,
+    DatabaseEntity,
+    HostEntity,
+    ScheduleEntry,
 )
 
 
@@ -194,4 +195,22 @@ class IOracleRmanRepository(ABC):
         from_date: Optional[datetime] = None,
         to_date: Optional[datetime] = None,
     ) -> List[BackupJobResult]:
+        ...
+
+    @abstractmethod
+    def get_backup_job_detail(
+        self,
+        db_key: int,
+        session_key: int,
+    ) -> Optional[BackupJobResult]:
+        """Return a single BackupJobResult for the given db_key/session_key."""
+        ...
+
+    @abstractmethod
+    def get_backup_log(
+        self,
+        db_key: int,
+        session_key: int,
+    ) -> List[BackupLogEntry]:
+        """Return RMAN output lines from RC_RMAN_OUTPUT for the given session."""
         ...

--- a/coreRelback/gateways/repositories.py
+++ b/coreRelback/gateways/repositories.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from coreRelback.domain.entities import (
     BackupDestination,
     BackupJobResult,
+    BackupLogEntry,
     BackupPolicyEntity,
     BackupStatusValue,
     BackupType,
@@ -384,7 +385,8 @@ FETCH FIRST 500 ROWS ONLY"""
             conditions.append("START_TIME < :to_date + INTERVAL '1' DAY")
             params["to_date"] = to_date
 
-        where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        where_clause = ("WHERE " + " AND ".join(conditions)
+                        ) if conditions else ""
         sql = self._SQL.format(where=where_clause)
 
         try:
@@ -395,7 +397,6 @@ FETCH FIRST 500 ROWS ONLY"""
         except Exception as exc:
             _logger.error("RMAN catalog query failed: %s", exc)
             return []
-
 
     @staticmethod
     def _row_to_entity(row: tuple) -> BackupJobResult:
@@ -413,3 +414,89 @@ FETCH FIRST 500 ROWS ONLY"""
             session_key=row[9],
             input_type=row[10],
         )
+
+    _SQL_DETAIL = """\
+SELECT
+    DB_NAME,
+    DBID,
+    START_TIME,
+    END_TIME,
+    STATUS,
+    INPUT_TYPE,
+    OUTPUT_BYTES_DISPLAY,
+    TIME_TAKEN_DISPLAY,
+    OUTPUT_DEVICE_TYPE,
+    SESSION_KEY,
+    INPUT_TYPE
+FROM RC_BACKUP_JOB_DETAILS
+WHERE DB_KEY = :db_key
+  AND SESSION_KEY = :session_key
+FETCH FIRST 1 ROWS ONLY"""
+
+    _SQL_LOG = """\
+SELECT RECID, OUTPUT, STAMP
+FROM RC_RMAN_OUTPUT
+WHERE DB_KEY = :db_key
+  AND SESSION_RECID = :session_key
+ORDER BY RECID"""
+
+    def get_backup_job_detail(
+        self,
+        db_key: int,
+        session_key: int,
+    ) -> Optional[BackupJobResult]:
+        """Return a single BackupJobResult for the given db_key / session_key.
+
+        Returns None when the Oracle catalog is unavailable or the record
+        is not found — never raises to the caller.
+        """
+        from coreRelback.gateways.oracle_catalog import get_catalog_connection
+        import logging as _log
+        _logger = _log.getLogger(__name__)
+
+        conn = get_catalog_connection()
+        if conn is None:
+            return None
+        try:
+            with conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    self._SQL_DETAIL,
+                    {"db_key": db_key, "session_key": session_key},
+                )
+                row = cursor.fetchone()
+                return self._row_to_entity(row) if row else None
+        except Exception as exc:
+            _logger.error("RMAN detail query failed: %s", exc)
+            return None
+
+    def get_backup_log(
+        self,
+        db_key: int,
+        session_key: int,
+    ) -> List[BackupLogEntry]:
+        """Return RMAN output lines from RC_RMAN_OUTPUT for the given session.
+
+        Returns empty list when catalog unavailable or no output recorded.
+        """
+        from coreRelback.gateways.oracle_catalog import get_catalog_connection
+        import logging as _log
+        _logger = _log.getLogger(__name__)
+
+        conn = get_catalog_connection()
+        if conn is None:
+            return []
+        try:
+            with conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    self._SQL_LOG,
+                    {"db_key": db_key, "session_key": session_key},
+                )
+                return [
+                    BackupLogEntry(recid=row[0], output=row[1], stamp=row[2])
+                    for row in cursor
+                ]
+        except Exception as exc:
+            _logger.error("RMAN log query failed: %s", exc)
+            return []

--- a/coreRelback/services/use_cases.py
+++ b/coreRelback/services/use_cases.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 from coreRelback.domain.entities import (
     BackupJobResult,
+    BackupLogEntry,
     BackupPolicyEntity,
     BackupStatusValue,
     ClientEntity,
@@ -387,3 +388,41 @@ class DeleteBackupPolicyUseCase:
 
     def execute(self, policy_id: int) -> None:
         self._policies.delete(policy_id)
+
+
+# ---------------------------------------------------------------------------
+# Oracle RMAN Catalog — Log Detail Use Case
+# ---------------------------------------------------------------------------
+
+class GetBackupDetailUseCase:
+    """Fetch execution detail and RMAN output log for one backup session.
+
+    Single Responsibility: retrieve the two Oracle catalog datasets needed
+    by the ``report_read_log_detail`` view without leaking gateway details.
+    """
+
+    def __init__(self, rman_repo: IOracleRmanRepository):
+        self._rman = rman_repo
+
+    def execute(
+        self,
+        db_key: int,
+        session_key: int,
+    ) -> dict:
+        """Return a dict with keys ``exec_detail`` and ``report_log``.
+
+        Both keys are always present; values are ``None`` / ``[]`` when the
+        Oracle catalog is unavailable — the view must handle the empty state
+        gracefully.
+        """
+        exec_detail: Optional[BackupJobResult] = self._rman.get_backup_job_detail(
+            db_key=db_key, session_key=session_key
+        )
+        report_log: List[BackupLogEntry] = self._rman.get_backup_log(
+            db_key=db_key, session_key=session_key
+        )
+        return {
+            "exec_detail": exec_detail,
+            "report_log": report_log,
+            "oracle_available": exec_detail is not None or len(report_log) > 0,
+        }

--- a/coreRelback/templates/reportsReadLog.html
+++ b/coreRelback/templates/reportsReadLog.html
@@ -23,13 +23,13 @@
                 </tr>
                 <tr>
                     <th>Client</th>
-                    <td>{{ policyDetail.id_client.name }}</td>
+                    <td>{{ policyDetail.client.name }}</td>
                     <th>Database (DB_NAME)</th>
-                    <td>{{ policyDetail.id_database.db_name }}</td>
+                    <td>{{ policyDetail.database.db_name }}</td>
                 </tr>
                 <tr>
                     <th>Hostname</th>
-                    <td>{{ policyDetail.id_host.hostname }}</td>
+                    <td>{{ policyDetail.host.hostname }}</td>
                     <th>Duration Estimated</th>
                     <td>{{ policyDetail.duration }} Minutes</td>
                 </tr>

--- a/coreRelback/tests.py
+++ b/coreRelback/tests.py
@@ -261,3 +261,66 @@ class BackupBadgeTagTests(SimpleTestCase):
         from coreRelback.domain.entities import BackupStatusValue
         html = self._render(BackupStatusValue.FAILED)
         self.assertIn("badge-error", html)
+
+
+# ---------------------------------------------------------------------------
+# Report Log Detail View Integration Tests
+# ---------------------------------------------------------------------------
+
+class ReportLogDetailViewTests(TestCase):
+    """Integration tests for the report_read_log_detail view.
+
+    No real Oracle catalog required — settings_test.py sets ORACLE_CATALOG=None.
+    The view must render gracefully with an empty log and no exec detail.
+    """
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        self.user = User.objects.create_superuser(
+            username="logdetail_admin",
+            password="testpass123",
+            email="logdetail@example.com",
+        )
+        self.client.force_login(self.user)
+
+    def _url(self, policy_id=999, db_key=1, session_key=1):
+        return reverse(
+            "coreRelback:report-read-log-detail",
+            kwargs={"idPolicy": policy_id, "dbKey": db_key,
+                    "sessionKey": session_key},
+        )
+
+    def test_log_detail_redirects_unauthenticated(self):
+        """Unauthenticated users must be redirected to login."""
+        self.client.logout()
+        response = self.client.get(self._url())
+        self.assertIn(response.status_code, (302, 301))
+        self.assertIn("/login/", response["Location"])
+
+    def test_log_detail_renders_template(self):
+        """Authenticated GET must render reportsReadLog.html with 200."""
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "reportsReadLog.html")
+
+    def test_log_detail_context_keys_present(self):
+        """View must supply all context keys consumed by the template."""
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        for key in ("policyDetail", "execDetail", "reportLog", "oracle_available",
+                    "idPolicy", "dbKey", "sessionKey"):
+            self.assertIn(key, response.context,
+                          f"'{key}' missing from report_read_log_detail context")
+
+    def test_log_detail_oracle_unavailable_in_test_env(self):
+        """Oracle catalog is None in test env — execDetail=None, reportLog=[], oracle_available=False."""
+        response = self.client.get(self._url())
+        self.assertIs(response.context["oracle_available"], False)
+        self.assertIsNone(response.context["execDetail"])
+        self.assertEqual(response.context["reportLog"], [])
+
+    def test_log_detail_policy_not_found_no_500(self):
+        """When idPolicy doesn't exist in SQLite, policyDetail=None and view returns 200."""
+        response = self.client.get(self._url(policy_id=99999))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["policyDetail"])

--- a/coreRelback/tests_domain.py
+++ b/coreRelback/tests_domain.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from coreRelback.domain.entities import (
     BackupDestination,
     BackupJobResult,
+    BackupLogEntry,
     BackupPolicyEntity,
     BackupStatusValue,
     BackupType,
@@ -34,6 +35,7 @@ from coreRelback.gateways.interfaces import (
 from coreRelback.gateways.repositories import OracleRmanRepository
 from coreRelback.services.use_cases import (
     AuditBackupUseCase,
+    GetBackupDetailUseCase,
     CreateBackupPolicyUseCase,
     CreateClientUseCase,
     CreateDatabaseUseCase,
@@ -221,11 +223,19 @@ class StubScheduleRepo(IScheduleRepository):
 
 
 class StubRmanRepo(IOracleRmanRepository):
-    def __init__(self, jobs=None):
+    def __init__(self, jobs=None, detail=None, log=None):
         self._jobs = jobs or []
+        self._detail = detail
+        self._log = log or []
 
     def get_backup_jobs(self, **kwargs) -> List[BackupJobResult]:
         return list(self._jobs)
+
+    def get_backup_job_detail(self, db_key: int, session_key: int) -> Optional[BackupJobResult]:
+        return self._detail
+
+    def get_backup_log(self, db_key: int, session_key: int) -> List[BackupLogEntry]:
+        return list(self._log)
 
 
 # ---------------------------------------------------------------------------
@@ -700,3 +710,97 @@ class OracleRmanRepositoryUnavailableTest(TestCase):
             use_case = AuditBackupUseCase(OracleRmanRepository())
             result = use_case.execute()
             self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# GetBackupDetailUseCase Tests
+# ---------------------------------------------------------------------------
+
+class GetBackupDetailUseCaseTest(TestCase):
+    """Tests for GetBackupDetailUseCase using stub repository."""
+
+    def _make_job(self, session_key=42):
+        return BackupJobResult(
+            db_name="ORCL", dbid=100,
+            status=BackupStatusValue.COMPLETED,
+            session_key=session_key,
+            time_taken_display="00:05:30",
+            output_bytes_display="1.23G",
+        )
+
+    def _make_log_entry(self, recid=1):
+        return BackupLogEntry(recid=recid, output="RMAN> backup database;")
+
+    def test_returns_exec_detail_and_log_from_stub(self):
+        job = self._make_job()
+        log = [self._make_log_entry()]
+        repo = StubRmanRepo(detail=job, log=log)
+        result = GetBackupDetailUseCase(repo).execute(db_key=1, session_key=42)
+        self.assertEqual(result["exec_detail"], job)
+        self.assertEqual(result["report_log"], log)
+
+    def test_oracle_available_true_when_detail_present(self):
+        repo = StubRmanRepo(detail=self._make_job(), log=[])
+        result = GetBackupDetailUseCase(repo).execute(db_key=1, session_key=42)
+        self.assertTrue(result["oracle_available"])
+
+    def test_oracle_available_true_when_log_non_empty(self):
+        repo = StubRmanRepo(detail=None, log=[self._make_log_entry()])
+        result = GetBackupDetailUseCase(repo).execute(db_key=1, session_key=42)
+        self.assertTrue(result["oracle_available"])
+
+    def test_oracle_available_false_when_both_empty(self):
+        repo = StubRmanRepo(detail=None, log=[])
+        result = GetBackupDetailUseCase(repo).execute(db_key=1, session_key=42)
+        self.assertFalse(result["oracle_available"])
+
+    def test_returns_empty_state_when_catalog_unavailable(self):
+        """OracleRmanRepository returns None/[] when catalog connection is None."""
+        with patch(
+            "coreRelback.gateways.oracle_catalog.get_catalog_connection",
+            return_value=None,
+        ):
+            repo = OracleRmanRepository()
+            result = GetBackupDetailUseCase(
+                repo).execute(db_key=1, session_key=99)
+        self.assertIsNone(result["exec_detail"])
+        self.assertEqual(result["report_log"], [])
+        self.assertFalse(result["oracle_available"])
+
+
+class BackupLogEntryEntityTest(TestCase):
+    """Tests for the BackupLogEntry domain entity."""
+
+    def test_fields_stored_correctly(self):
+        entry = BackupLogEntry(
+            recid=7, output="RMAN> backup incremental level 0;", stamp=12345)
+        self.assertEqual(entry.recid, 7)
+        self.assertEqual(entry.output, "RMAN> backup incremental level 0;")
+        self.assertEqual(entry.stamp, 12345)
+
+    def test_stamp_optional_defaults_none(self):
+        entry = BackupLogEntry(recid=1, output="output line")
+        self.assertIsNone(entry.stamp)
+
+
+class OracleRmanRepositoryDetailUnavailableTest(TestCase):
+    """Unit tests for OracleRmanRepository.get_backup_job_detail / get_backup_log
+    when catalog is unavailable (no real Oracle needed)."""
+
+    def test_get_backup_job_detail_returns_none_when_unavailable(self):
+        with patch(
+            "coreRelback.gateways.oracle_catalog.get_catalog_connection",
+            return_value=None,
+        ):
+            repo = OracleRmanRepository()
+            result = repo.get_backup_job_detail(db_key=1, session_key=99)
+        self.assertIsNone(result)
+
+    def test_get_backup_log_returns_empty_list_when_unavailable(self):
+        with patch(
+            "coreRelback.gateways.oracle_catalog.get_catalog_connection",
+            return_value=None,
+        ):
+            repo = OracleRmanRepository()
+            result = repo.get_backup_log(db_key=1, session_key=99)
+        self.assertEqual(result, [])

--- a/coreRelback/views.py
+++ b/coreRelback/views.py
@@ -35,6 +35,7 @@ from coreRelback.services.use_cases import (
     CreateBackupPolicyUseCase,
     UpdateBackupPolicyUseCase,
     DeleteBackupPolicyUseCase,
+    GetBackupDetailUseCase,
 )
 
 
@@ -672,10 +673,40 @@ def report_read(request):
     return render(request, "reports.html", context)
 
 
-
+@login_required
 @login_required
 def report_read_log_detail(request, idPolicy, dbKey, sessionKey):
-    context = {"idPolicy": idPolicy, "dbKey": dbKey, "sessionKey": sessionKey}
+    """Backup session log detail view.
+
+    Fetches:
+    - ``policyDetail`` — BackupPolicy ORM instance for metadata
+    - ``execDetail``   — BackupJobResult entity (RC_BACKUP_JOB_DETAILS)
+    - ``reportLog``    — list of BackupLogEntry entities (RC_RMAN_OUTPUT)
+
+    Renders gracefully when Oracle catalog is unavailable.
+    """
+    from coreRelback.models import BackupPolicy
+
+    try:
+        policy = BackupPolicy.objects.select_related(
+            'client', 'host', 'database'
+        ).get(pk=idPolicy)
+    except BackupPolicy.DoesNotExist:
+        policy = None
+
+    detail_result = GetBackupDetailUseCase(OracleRmanRepository()).execute(
+        db_key=dbKey, session_key=sessionKey
+    )
+
+    context = {
+        "idPolicy": idPolicy,
+        "dbKey": dbKey,
+        "sessionKey": sessionKey,
+        "policyDetail": policy,
+        "execDetail": detail_result["exec_detail"],
+        "reportLog": detail_result["report_log"],
+        "oracle_available": detail_result["oracle_available"],
+    }
     return render(request, "reportsReadLog.html", context)
 
 
@@ -696,7 +727,8 @@ def register_view(request):
         form = RelbackUserCreationForm(request.POST)
         if form.is_valid():
             form.save()
-            messages.success(request, "Account created successfully. Please sign in.")
+            messages.success(
+                request, "Account created successfully. Please sign in.")
             return redirect('coreRelback:login')
     else:
         form = RelbackUserCreationForm()


### PR DESCRIPTION
## Summary
Implements the `report_read_log_detail` view which was previously a stub returning only route parameters.

## Changes

### Domain Layer
- **`BackupLogEntry`** dataclass added to `domain/entities.py` — represents one RMAN output line from `RC_RMAN_OUTPUT`

### Interface Adapter — Gateway
- **`IOracleRmanRepository`**: two new abstract methods
  - `get_backup_job_detail(db_key, session_key) → Optional[BackupJobResult]`
  - `get_backup_log(db_key, session_key) → List[BackupLogEntry]`
- **`OracleRmanRepository`**: concrete implementations using:
  - `RC_BACKUP_JOB_DETAILS WHERE DB_KEY=:db_key AND SESSION_KEY=:session_key`
  - `RC_RMAN_OUTPUT WHERE DB_KEY=:db_key AND SESSION_RECID=:session_key ORDER BY RECID`
  - Both return gracefully (None / []) when Oracle catalog is unavailable

### Use Case (Business Logic)
- **`GetBackupDetailUseCase`** added to `use_cases.py` — returns `{exec_detail, report_log, oracle_available}`

### Controller (View)
- **`report_read_log_detail`** now: fetches `BackupPolicy` via ORM, calls use case, passes all context keys to template
- Fixed `@login_required` decorator (was missing from stub)
- Fixed `select_related('client', 'host', 'database')` (corrected from wrong `id_*` field names)

### Template
- Updated field accessors: `policyDetail.client.name`, `policyDetail.host.hostname`, `policyDetail.database.db_name`

### Tests
- **Domain tests** (+9): `GetBackupDetailUseCaseTest`, `BackupLogEntryEntityTest`, `OracleRmanRepositoryDetailUnavailableTest`
- **Integration tests** (+5): `ReportLogDetailViewTests` (unauthenticated redirect, template rendered, context keys, oracle unavailable state, missing policy)
- **`StubRmanRepo`** extended to implement new interface methods

## Gate Results
- ✅ Gate 1: `manage.py check --settings=settings_dev` → 0 issues
- ✅ Gate 2: 46/46 domain tests pass
- ✅ Gate 3: 37/37 integration tests pass

Closes #37