### PR TITLE
[CI] Add djlint template-lint gate — prevent formatter regression (#43)

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,7 @@
+{
+  "profile": "django",
+  "ignore": "H006,H021,H025,H030,H031,T002,T032",
+  "indent": 2,
+  "max_line_length": 120,
+  "format_attribute_template_tags": true
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,28 @@ jobs:
         # Oracle PL/SQL files are excluded via .sqlfluffignore; see that file for rationale.
         run: sqlfluff lint databaseProject/
 
+  template-lint:
+    name: Django Template Lint (djlint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install djlint
+        run: pip install "djlint>=1.36.0,<2.0"
+
+      - name: Lint Django templates
+        # Config is read from .djlintrc at repo root.
+        # Enforces T003 (named endblocks) to prevent formatter-collapse regressions.
+        run: djlint coreRelback/templates/ --lint
+
   tailwind-build:
     name: Tailwind CSS Build Sensor (Node 20)
     runs-on: ubuntu-latest

--- a/coreRelback/templates/base.html
+++ b/coreRelback/templates/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{% block title %}RelBack - Oracle Report Backup{% endblock %}</title>
+    <title>{% block title %}RelBack - Oracle Report Backup{% endblock title %}</title>
     {# FOUC prevention: restore saved DaisyUI theme BEFORE first CSS paint #}
     <script>
       (function () {
@@ -29,7 +29,7 @@
     <!-- Legacy content CSS: md-card, md-badge, md-btn etc. — remove per Phase 4 migration -->
     <link href="{% static 'css/oracle-modern-theme.css' %}" rel="stylesheet" />
 
-    {% block extra_css %}{% endblock %}
+    {% block extra_css %}{% endblock extra_css %}
   </head>
   <body>
     {# ────────────────────────────────────────────────────────────────────
@@ -63,7 +63,7 @@
                   relBack
                 </a>
               </li>
-              {% block breadcrumb %}{% endblock %}
+              {% block breadcrumb %}{% endblock breadcrumb %}
             </ul>
           </div>
 
@@ -148,7 +148,7 @@
 
         {# Main Page Content ─────────────────────────────────────────── #}
         <main class="flex-1 p-4">
-          {% block content %}{% endblock %}
+          {% block content %}{% endblock content %}
         </main>
 
         {# Footer ──────────────────────────────────────────────────── #}
@@ -293,6 +293,6 @@
       }, 5000);
     </script>
 
-    {% block extra_js %}{% endblock %}
+    {% block extra_js %}{% endblock extra_js %}
   </body>
 </html>

--- a/coreRelback/templates/client_confirm_delete.html
+++ b/coreRelback/templates/client_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Delete Client - RelBack{% endblock %}
+{% block title %}Delete Client - RelBack{% endblock title %}
 
 {% block content %}
 <div>
@@ -131,4 +131,4 @@ document.getElementById('deleteForm').addEventListener('submit', function(e) {
     }
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/client_form.html
+++ b/coreRelback/templates/client_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}{% if object %}Edit Client{% else %}Add Client{% endif %} - RelBack{% endblock %}
+{% block title %}{% if object %}Edit Client{% else %}Add Client{% endif %} - RelBack{% endblock title %}
 
 {% block content %}
 <div>
@@ -179,4 +179,4 @@ document.getElementById('id_name').addEventListener('input', function() {
     }
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/clients.html
+++ b/coreRelback/templates/clients.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Clients - RelBack{% endblock %}
+{% block title %}Clients - RelBack{% endblock title %}
 
 {% block content %}
 <div class="md-container-fluid">
@@ -904,4 +904,4 @@ if (deleteBtn) {
     });
 }
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/creators.html
+++ b/coreRelback/templates/creators.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %} relBack - Creators {% endblock %}
+{% block title %} relBack - Creators {% endblock title %}
 
 {%  block content  %}
 
@@ -117,4 +117,4 @@
             </div>
 		</div><!-- div container -->
 
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/database_confirm_delete.html
+++ b/coreRelback/templates/database_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Confirmar Exclusão - Banco de Dados{% endblock %}
+{% block title %}Confirmar Exclusão - Banco de Dados{% endblock title %}
 
 {% block content %}
 <div class="flex justify-center">
@@ -43,4 +43,4 @@
         </div>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/database_form.html
+++ b/coreRelback/templates/database_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Database Form{% endblock %}
+{% block title %}Database Form{% endblock title %}
 
 {% block content %}
   <h2>{% if form.instance.pk %}Edit Database{% else %}Create Database{% endif %}</h2>
@@ -10,4 +10,4 @@
       {% if form.instance.pk %}Update{% else %}Create{% endif %}
     </button>
   </form>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/databases.html
+++ b/coreRelback/templates/databases.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Databases - RelBack{% endblock %}
+{% block title %}Databases - RelBack{% endblock title %}
 
 {% block content %}
 <div class="md-container-fluid">
@@ -1033,4 +1033,4 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/host_confirm_delete.html
+++ b/coreRelback/templates/host_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Confirmar Exclusão - Host{% endblock %}
+{% block title %}Confirmar Exclusão - Host{% endblock title %}
 
 {% block content %}
 <div class="flex justify-center">
@@ -42,4 +42,4 @@
         </div>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/host_form.html
+++ b/coreRelback/templates/host_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}{% if object %}Edit Host{% else %}Add Host{% endif %} - RelBack{% endblock %}
+{% block title %}{% if object %}Edit Host{% else %}Add Host{% endif %} - RelBack{% endblock title %}
 
 {% block content %}
 <div>
@@ -382,4 +382,4 @@ document.getElementById('testConnection').addEventListener('click', function() {
 });
 {% endif %}
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/hosts.html
+++ b/coreRelback/templates/hosts.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Hosts - RelBack{% endblock %}
+{% block title %}Hosts - RelBack{% endblock title %}
 
 {% block content %}
 <div class="md-container-fluid">
@@ -1152,4 +1152,4 @@ document.addEventListener('keydown', function(e) {
 });
 
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/index.html
+++ b/coreRelback/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Dashboard - RelBack{% endblock %}
+{% block title %}Dashboard - RelBack{% endblock title %}
 
 {% block content %}
 <div>
@@ -240,4 +240,4 @@ document.getElementById('quickAddFab').addEventListener('click', function() {
     alert('Quick add functionality - could show a dropdown with add options');
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/policies.html
+++ b/coreRelback/templates/policies.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Backup Policies - RelBack{% endblock %}
+{% block title %}Backup Policies - RelBack{% endblock title %}
 
 {% block content %}
 <div class="md-container-fluid">
@@ -1012,4 +1012,4 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/policy_confirm_delete.html
+++ b/coreRelback/templates/policy_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Confirmar Exclusão - Política de Backup{% endblock %}
+{% block title %}Confirmar Exclusão - Política de Backup{% endblock title %}
 
 {% block content %}
 <div class="flex justify-center">
@@ -44,4 +44,4 @@
         </div>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/policy_form.html
+++ b/coreRelback/templates/policy_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Policy Form{% endblock %}
+{% block title %}Policy Form{% endblock title %}
 
 {% block content %}
   <h2>{% if form.instance.pk %}Edit Policy{% else %}Create Policy{% endif %}</h2>
@@ -10,4 +10,4 @@
       {% if form.instance.pk %}Update{% else %}Create{% endif %}
     </button>
   </form>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/reports.html
+++ b/coreRelback/templates/reports.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load backup_tags %}
 
-{% block title %}Reports - RelBack{% endblock %}
+{% block title %}Reports - RelBack{% endblock title %}
 
 {% block content %}
 <div class="md-container-fluid">
@@ -431,7 +431,7 @@
     </div>
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
-{% endblock %}
+{% endblock content %}
 
 {% block extra_js %}
 <style>
@@ -1921,4 +1921,4 @@ setInterval(function() {
     console.log('Auto-refresh check...');
 }, 30000);
 </script>
-{% endblock %}
+{% endblock extra_js %}

--- a/coreRelback/templates/reportsReadLog.html
+++ b/coreRelback/templates/reportsReadLog.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
-{% block title %}Report Log Detail{% endblock %}
+{% block title %}Report Log Detail{% endblock title %}
 {% block content %}
 <div class="container mx-auto px-4 mt-5">
   <h1 class="mb-4">Report Backup Policy Detail</h1>
@@ -81,4 +81,4 @@
     >
   </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/coreRelback/templates/user_settings.html
+++ b/coreRelback/templates/user_settings.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}User Settings - RelBack{% endblock %}
+{% block title %}User Settings - RelBack{% endblock title %}
 
 {% block content %}
 <div class="flex justify-center">
@@ -167,4 +167,4 @@ document.getElementById('new_password').addEventListener('input', function() {
     }
 });
 </script>
-{% endblock %}
+{% endblock content %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=6.0.3,<7.0
 oracledb>=3.4.2,<4.0
 django-tables2>=2.8.0,<3.0
 django-tailwind[reload]>=3.8.0,<4.0
+djlint>=1.36.0,<2.0


### PR DESCRIPTION
## Summary

Closes #43

Adds **djlint** as a dedicated CI gate to permanently prevent the recurring Django template formatter regression pattern (3 occurrences: PRs #38, #40, #42).

## Changes

### New: `.djlintrc`
- `profile: django`
- Enforces **T003** (named endblocks) — the key formatter-regression prevention rule
- Suppresses noise rules: H021 (Material Icons inline styles), T002 (single quotes), H006/H025/H030/H031/T032

### Updated: `requirements.txt`
- Added `djlint>=1.36.0,<2.0`

### Updated: `.github/workflows/ci.yml`
- New `template-lint` job: `djlint coreRelback/templates/ --lint`
- Config auto-loaded from `.djlintrc`

### Fixed: All 20 `coreRelback/templates/*.html`
- Added block names to all 40 unnamed `{% endblock %}` → `{% endblock content %}`, `{% endblock title %}`, etc.
- Explicit block names make template structure self-documenting and harder to mis-format

## Sensor Gates

- ✅ Gate 1: `python manage.py check` — 0 issues
- ✅ Gate 2: 46 domain tests — OK
- ✅ Gate 3: 37 integration tests — OK
- ✅ djlint: `Linted 20 files, found 0 errors.`