### PR TITLE
[CORE] Demo mode — seed_demo command + DemoRmanRepository (#45)

### DIFF
--- a/coreRelback/gateways/repositories.py
+++ b/coreRelback/gateways/repositories.py
@@ -500,3 +500,121 @@ ORDER BY RECID"""
         except Exception as exc:
             _logger.error("RMAN log query failed: %s", exc)
             return []
+
+
+# ---------------------------------------------------------------------------
+# Demo Repository — returns in-memory fixture data when DEMO_MODE = True
+# ---------------------------------------------------------------------------
+
+class DemoRmanRepository(IOracleRmanRepository):
+    """
+    In-memory implementation of IOracleRmanRepository.
+
+    Returns realistic fake RMAN backup data so the web interface can be
+    previewed without an Oracle Catalog connection.
+    Activated automatically when settings.DEMO_MODE is True.
+    """
+
+    _JOBS: List[BackupJobResult] = None  # populated lazily on first call
+
+    def _load_jobs(self) -> List[BackupJobResult]:
+        from datetime import datetime, timedelta
+        import random
+
+        databases = [
+            ("ORCL",  3951648617,  10001),
+            ("PROD",  1234567890,  10002),
+            ("DEV",   9876543210,  10003),
+            ("DW",    1122334455,  10004),
+            ("TEST",  5544332211,  10005),
+        ]
+        statuses = [
+            BackupStatusValue.COMPLETED,
+            BackupStatusValue.COMPLETED,
+            BackupStatusValue.COMPLETED,
+            BackupStatusValue.FAILED,
+            BackupStatusValue.WARNING,
+            BackupStatusValue.COMPLETED,
+            BackupStatusValue.RUNNING,
+        ]
+        types = ["DB FULL", "ARCHIVELOG", "DB INCR", "DB FULL", "ARCHIVELOG"]
+        devices = ["DISK", "DISK", "SBT_TAPE"]
+
+        now = datetime.now()
+        jobs = []
+        key = 1
+        random.seed(42)
+        for i in range(30):
+            db_name, dbid, db_key = databases[i % len(databases)]
+            status = statuses[i % len(statuses)]
+            start = now - timedelta(hours=random.randint(1, 168))
+            duration_min = random.randint(5, 480)
+            end = start + timedelta(minutes=duration_min)
+            size_gb = round(random.uniform(0.5, 120.0), 2)
+            jobs.append(BackupJobResult(
+                db_name=db_name,
+                dbid=dbid,
+                db_key=db_key,
+                session_key=key,
+                session_recid=key,
+                session_stamp=100000 + key,
+                start_time=start,
+                end_time=end if status != BackupStatusValue.RUNNING else None,
+                status=status,
+                input_type=types[i % len(types)],
+                output_bytes_display=f"{size_gb} GB",
+                output_device_type=devices[i % len(devices)],
+                time_taken_display=f"{duration_min // 60}h {duration_min % 60}m",
+            ))
+            key += 1
+        return sorted(jobs, key=lambda j: j.start_time or now, reverse=True)
+
+    def get_backup_jobs(self, days: int = 7) -> List[BackupJobResult]:
+        if DemoRmanRepository._JOBS is None:
+            DemoRmanRepository._JOBS = self._load_jobs()
+        return DemoRmanRepository._JOBS
+
+    def get_running_jobs_count(self) -> int:
+        return sum(
+            1 for j in self.get_backup_jobs()
+            if j.status == BackupStatusValue.RUNNING
+        )
+
+    def get_backup_job_detail(self, db_key: int, session_key: int) -> Optional[BackupJobResult]:
+        for job in self.get_backup_jobs():
+            if job.db_key == db_key and job.session_key == session_key:
+                return job
+        return None
+
+    def get_backup_log(self, db_key: int, session_key: int) -> List[BackupLogEntry]:
+        from datetime import datetime
+        sample_log = [
+            "RMAN> run {",
+            "  backup incremental level 0 database;",
+            "}",
+            "",
+            "Starting backup at {ts}",
+            "allocated channel: ORA_DISK_1",
+            "channel ORA_DISK_1: SID=42 device type=DISK",
+            "channel ORA_DISK_1: starting full datafile backup set",
+            "channel ORA_DISK_1: specifying datafile(s) in backup set",
+            "input datafile file number=00001 name=/oradata/system01.dbf",
+            "input datafile file number=00002 name=/oradata/sysaux01.dbf",
+            "input datafile file number=00003 name=/oradata/undotbs01.dbf",
+            "input datafile file number=00004 name=/oradata/users01.dbf",
+            "channel ORA_DISK_1: starting piece 1 at {ts}",
+            "channel ORA_DISK_1: finished piece 1 at {ts}",
+            "piece handle=/backup/orcl/bkp_20260303_001.bkp tag=TAG20260303T020001 comment=NONE",
+            "channel ORA_DISK_1: backup set complete, elapsed time: 00:14:22",
+            "Finished backup at {ts}",
+            "",
+            "Starting Control File and SPFILE Autobackup at {ts}",
+            "piece handle=/backup/orcl/c-3951648617-20260303-00 comment=NONE",
+            "Finished Control File and SPFILE Autobackup at {ts}",
+            "Recovery Manager complete.",
+        ]
+        ts = datetime.now().strftime("%d-%b-%Y %H:%M:%S")
+        return [
+            BackupLogEntry(recid=i + 1, output=line.replace("{ts}", ts), stamp=None)
+            for i, line in enumerate(sample_log)
+        ]

--- a/coreRelback/management/commands/seed_demo.py
+++ b/coreRelback/management/commands/seed_demo.py
@@ -1,0 +1,181 @@
+"""
+Management command: seed_demo
+
+Populates the SQLite database with realistic fictitious data so the UI
+can be previewed locally without an Oracle connection.
+
+Usage:
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py migrate
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py seed_demo
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py runserver
+
+    Login: admin / demo1234
+
+Running again with --flush first wipes all data and reseeds from scratch:
+    python manage.py seed_demo --flush
+"""
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+
+DEMO_CLIENTS = [
+    {"name": "Acme Corp",        "description": "Retail e-commerce platform"},
+    {"name": "TechNova",         "description": "SaaS product company"},
+    {"name": "GlobalBank",       "description": "Core banking systems"},
+    {"name": "MediCare Systems", "description": "Hospital management & HL7"},
+]
+
+DEMO_HOSTS = [
+    # (client_idx, hostname, ip, description)
+    (0, "acme-db01",   "10.0.0.11", "Primary Oracle node"),
+    (0, "acme-db02",   "10.0.0.12", "DR standby node"),
+    (1, "nova-db01",   "10.1.0.11", "Production Oracle 19c"),
+    (1, "nova-db02",   "10.1.0.12", "Reporting replica"),
+    (2, "bank-db01",   "10.2.0.11", "Core banking DB primary"),
+    (2, "bank-db02",   "10.2.0.12", "Core banking DB standby"),
+    (2, "bank-dw01",   "10.2.0.13", "Data warehouse"),
+    (3, "medi-db01",   "10.3.0.11", "Patient records DB"),
+]
+
+DEMO_DATABASES = [
+    # (host_idx, client_idx, db_name, description, dbid)
+    (0, 0, "ACMEPROD",  "Production OLTP DB",           3951648617),
+    (1, 0, "ACMEDR",    "DR standby OLTP DB",           3951648618),
+    (2, 1, "NOVAPROD",  "Production SaaS database",     1234567890),
+    (3, 1, "NOVAREP",   "Reporting read-only DB",       1234567891),
+    (4, 2, "BANKCORE",  "Core banking OLTP",            9876543210),
+    (5, 2, "BANKDR",    "Core banking DR",              9876543211),
+    (6, 2, "BANKDW",    "Data warehouse",               1122334455),
+    (7, 3, "MEDIEHR",   "Electronic health records",    5544332211),
+]
+
+DEMO_POLICIES = [
+    # (db_idx, host_idx, client_idx, policy_name, backup_type, dest, minute, hour, day, month, day_week, duration, size)
+    (0, 0, 0, "ACMEPROD Full Daily",    "DB FULL",     "DISK",     "0", "2",  "*", "*", "0,6",  120, "50G"),
+    (0, 0, 0, "ACMEPROD Arch Hourly",   "ARCHIVELOG",  "DISK",     "30","*",  "*", "*", "*",     15, "2G"),
+    (2, 2, 1, "NOVA Full Weekly",       "DB FULL",     "SBT_TAPE", "0", "1",  "*", "*", "0",    180, "80G"),
+    (2, 2, 1, "NOVA Incr Daily",        "DB INCR",     "DISK",     "0", "3",  "*", "*", "1-6",   60, "10G"),
+    (4, 4, 2, "BANK Full Daily",        "DB FULL",     "SBT_TAPE", "0", "0",  "*", "*", "*",    240, "200G"),
+    (4, 4, 2, "BANK Arch 30min",        "ARCHIVELOG",  "DISK",     "*/30","*","*", "*", "*",     10, "5G"),
+    (6, 6, 2, "DW Full Weekly",         "DB FULL",     "SBT_TAPE", "0", "4",  "*", "*", "0",    360, "500G"),
+    (7, 7, 3, "MEDI Full Daily",        "DB FULL",     "DISK",     "0", "1",  "*", "*", "*",    120, "30G"),
+]
+
+
+class Command(BaseCommand):
+    help = "Seed the database with fictitious demo data for local UI preview."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--flush",
+            action="store_true",
+            help="Delete all existing data before seeding.",
+        )
+
+    def handle(self, *args, **options):
+        from coreRelback.models import (
+            RelbackUser, Client, Host, Database, BackupPolicy
+        )
+
+        if options["flush"]:
+            self.stdout.write(self.style.WARNING("Flushing all existing data…"))
+            BackupPolicy.objects.all().delete()
+            Database.objects.all().delete()
+            Host.objects.all().delete()
+            Client.objects.all().delete()
+            RelbackUser.objects.filter(username__startswith="demo").delete()
+
+        with transaction.atomic():
+            # 1. Admin user
+            admin, created = RelbackUser.objects.get_or_create(
+                username="admin",
+                defaults={
+                    "name": "Demo Admin",
+                    "email": "admin@relback.local",
+                    "status": 1,
+                },
+            )
+            if created or not admin.check_password("demo1234"):
+                admin.set_password("demo1234")
+                admin.save()
+                self.stdout.write(self.style.SUCCESS("  ✓ Created admin user (admin / demo1234)"))
+            else:
+                self.stdout.write("  · admin user already exists")
+
+            # 2. Clients
+            clients = []
+            for c in DEMO_CLIENTS:
+                obj, created = Client.objects.get_or_create(
+                    name=c["name"],
+                    defaults={"description": c["description"], "created_by": admin},
+                )
+                clients.append(obj)
+                status = "✓ Created" if created else "· Exists"
+                self.stdout.write(f"  {status}: Client {obj.name}")
+
+            # 3. Hosts
+            hosts = []
+            for client_idx, hostname, ip, description in DEMO_HOSTS:
+                obj, created = Host.objects.get_or_create(
+                    hostname=hostname,
+                    defaults={
+                        "ip": ip,
+                        "description": description,
+                        "client": clients[client_idx],
+                        "created_by": admin,
+                    },
+                )
+                hosts.append(obj)
+                status = "✓ Created" if created else "· Exists"
+                self.stdout.write(f"  {status}: Host {obj.hostname}")
+
+            # 4. Databases
+            databases = []
+            for host_idx, client_idx, db_name, description, dbid in DEMO_DATABASES:
+                obj, created = Database.objects.get_or_create(
+                    db_name=db_name,
+                    defaults={
+                        "description": description,
+                        "dbid": dbid,
+                        "host": hosts[host_idx],
+                        "client": clients[client_idx],
+                        "created_by": admin,
+                    },
+                )
+                databases.append(obj)
+                status = "✓ Created" if created else "· Exists"
+                self.stdout.write(f"  {status}: Database {obj.db_name}")
+
+            # 5. Backup Policies
+            for db_idx, host_idx, client_idx, name, btype, dest, minute, hour, day, month, day_week, duration, size in DEMO_POLICIES:
+                obj, created = BackupPolicy.objects.get_or_create(
+                    policy_name=name,
+                    defaults={
+                        "database": databases[db_idx],
+                        "host": hosts[host_idx],
+                        "client": clients[client_idx],
+                        "backup_type": btype,
+                        "destination": dest,
+                        "minute": minute,
+                        "hour": hour,
+                        "day": day,
+                        "month": month,
+                        "day_week": day_week,
+                        "duration": duration,
+                        "size_backup": size,
+                        "status": "ACTIVE",
+                        "description": f"Demo policy — {btype} to {dest}",
+                        "created_by": admin,
+                    },
+                )
+                status = "✓ Created" if created else "· Exists"
+                self.stdout.write(f"  {status}: Policy '{obj.policy_name}'")
+
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS("Demo seed complete!"))
+        self.stdout.write("")
+        self.stdout.write("  Run the server:")
+        self.stdout.write("  DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py runserver")
+        self.stdout.write("")
+        self.stdout.write("  Login: admin / demo1234")
+        self.stdout.write("  Reports will show simulated RMAN backup jobs (DEMO_MODE=True).")

--- a/coreRelback/views.py
+++ b/coreRelback/views.py
@@ -17,6 +17,7 @@ from coreRelback.gateways.repositories import (
     DjangoBackupPolicyRepository,
     DjangoScheduleRepository,
     OracleRmanRepository,
+    DemoRmanRepository,
 )
 from coreRelback.services.use_cases import (
     AuditBackupUseCase,
@@ -37,6 +38,20 @@ from coreRelback.services.use_cases import (
     DeleteBackupPolicyUseCase,
     GetBackupDetailUseCase,
 )
+
+
+def _get_rman_repo():
+    """Return the appropriate RMAN repository based on settings.
+
+    When ``DEMO_MODE = True``, returns ``DemoRmanRepository`` so the UI
+    renders with realistic fixture data even without an Oracle connection.
+    Otherwise uses ``OracleRmanRepository`` (which also gracefully returns
+    empty lists when ``ORACLE_CATALOG`` is None).
+    """
+    from django.conf import settings
+    if getattr(settings, "DEMO_MODE", False):
+        return DemoRmanRepository()
+    return OracleRmanRepository()
 
 
 def _get_relback_user(request):
@@ -558,7 +573,7 @@ def report_read(request):
     to_dt = (datetime.datetime.combine(to_date, datetime.time.max)
              if to_date else None)
 
-    backup_jobs = AuditBackupUseCase(OracleRmanRepository()).execute(
+    backup_jobs = AuditBackupUseCase(_get_rman_repo()).execute(
         from_date=from_dt, to_date=to_dt,
     )
     oracle_available = bool(backup_jobs)
@@ -694,7 +709,7 @@ def report_read_log_detail(request, idPolicy, dbKey, sessionKey):
     except BackupPolicy.DoesNotExist:
         policy = None
 
-    detail_result = GetBackupDetailUseCase(OracleRmanRepository()).execute(
+    detail_result = GetBackupDetailUseCase(_get_rman_repo()).execute(
         db_key=dbKey, session_key=sessionKey
     )
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,319 @@
+# Relback — System Architecture
+
+**Stack:** Django 6.0 · Python 3.13 · Oracle Database (oracledb) · SQLite (dev/test) · Tailwind CSS + DaisyUI  
+**Pattern:** Clean Architecture (Robert C. Martin) — strict dependency rule, inner layers never reference outer layers.
+
+---
+
+## 1. Architectural Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  OUTER LAYER — Infrastructure & Delivery                                │
+│                                                                          │
+│  ┌─────────────────┐  ┌──────────────────────────────────────────────┐  │
+│  │  Django Views   │  │  Templates (DaisyUI/Tailwind)                │  │
+│  │  (HTTP adapter) │  │  base.html, reports.html, index.html, …      │  │
+│  └────────┬────────┘  └──────────────────────────────────────────────┘  │
+│           │ calls                                                        │
+│  ┌────────▼────────────────────────────────────────────────────────────┐│
+│  │  USE CASES (Interactors)              coreRelback/services/          ││
+│  │  GetDashboardStatsUseCase                                            ││
+│  │  AuditBackupUseCase                                                  ││
+│  │  GetScheduleReportUseCase                                            ││
+│  │  GenerateScheduleUseCase                                             ││
+│  │  GetBackupDetailUseCase                                              ││
+│  │  Create/Update/Delete CRUD use cases (Client, Host, Database, Policy)││
+│  └────────┬────────────────────────────────────────────────────────────┘│
+│           │ depends on (interfaces only)                                 │
+│  ┌────────▼────────────────────────────────────────────────────────────┐│
+│  │  GATEWAY INTERFACES (Ports)           coreRelback/gateways/          ││
+│  │  IClientRepository                                                   ││
+│  │  IHostRepository                                                     ││
+│  │  IDatabaseRepository                                                 ││
+│  │  IBackupPolicyRepository                                             ││
+│  │  IScheduleRepository                                                 ││
+│  │  IOracleRmanRepository                                               ││
+│  └────────────────────────────────────────────────────────────────────-┘│
+│           ▲                                                              │
+│           │ implements                                                   │
+│  ┌────────┴────────────────────────────────────────────────────────────┐│
+│  │  CONCRETE REPOSITORIES                coreRelback/gateways/          ││
+│  │  DjangoClientRepository      → Django ORM (SQLite / Oracle)         ││
+│  │  DjangoHostRepository        → Django ORM                           ││
+│  │  DjangoDatabaseRepository    → Django ORM                           ││
+│  │  DjangoBackupPolicyRepository → Django ORM                          ││
+│  │  DjangoScheduleRepository    → Django ORM                           ││
+│  │  OracleRmanRepository        → python-oracledb (Thin mode)          ││
+│  │  DemoRmanRepository          → in-memory fixture data (DEMO_MODE)   ││
+│  └────────────────────────────────────────────────────────────────────-┘│
+│                                                                          │
+│  INNERMOST LAYER — Domain                                               │
+│  ┌────────────────────────────────────────────────────────────────────┐ │
+│  │  ENTITIES & VALUE OBJECTS             coreRelback/domain/entities.py │
+│  │  ClientEntity, HostEntity, DatabaseEntity, BackupPolicyEntity        │
+│  │  BackupJobResult, BackupLogEntry, ScheduleEntry, DashboardStats      │
+│  │  BackupStatusValue (enum), BackupType (enum), PolicyStatus (enum)    │
+│  └──────────────────────────────────────────────────────────────────── │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Dependency Rule
+
+> Code dependencies always point **inward** — from Infrastructure → Use Cases → Entities.  
+> Entities know nothing about Django. Use Cases know nothing about Oracle or HTTP.
+
+---
+
+## 2. Layer Details
+
+### 2.1 Domain Layer — `coreRelback/domain/entities.py`
+
+Pure Python dataclasses and enums. Zero imports from Django, Oracle, or any framework.
+
+| Symbol | Type | Purpose |
+|---|---|---|
+| `ClientEntity` | `@dataclass` | Business representation of a backup client |
+| `HostEntity` | `@dataclass` | Server/host that runs Oracle |
+| `DatabaseEntity` | `@dataclass` | Oracle database instance |
+| `BackupPolicyEntity` | `@dataclass` | RMAN backup policy with cron schedule |
+| `ScheduleEntry` | `@dataclass` | Expanded cron forecast entry |
+| `BackupJobResult` | `@dataclass` | One RMAN backup job from RC_RMAN_BACKUP_JOB_DETAILS |
+| `BackupLogEntry` | `@dataclass` | One output line from RC_RMAN_OUTPUT |
+| `DashboardStats` | `@dataclass` | Aggregated counts for dashboard |
+| `BackupStatusValue` | `Enum` | COMPLETED / FAILED / RUNNING / WARNING / INTERRUPTED / UNKNOWN |
+| `BackupType` | `Enum` | ARCHIVELOG / DB FULL / DB INCR / RECVR AREA / BACKUPSET |
+| `PolicyStatus` | `Enum` | ACTIVE / INACTIVE |
+| `BackupDestination` | `Enum` | DISK / SBT\_TAPE |
+
+### 2.2 Gateway Interfaces — `coreRelback/gateways/interfaces.py`
+
+Abstract base classes (Python `ABC`) that define the **ports**. Use cases depend only on these — they never import concrete repositories or ORM models.
+
+| Interface | Methods |
+|---|---|
+| `IClientRepository` | `get_all`, `get_by_id`, `count`, `create`, `update`, `delete` |
+| `IHostRepository` | `get_all`, `get_by_id`, `count`, `create`, `update`, `delete` |
+| `IDatabaseRepository` | `get_all`, `get_by_id`, `count`, `create`, `update`, `delete` |
+| `IBackupPolicyRepository` | `get_all`, `get_by_id`, `count`, `count_active`, `create`, `update`, `delete` |
+| `IScheduleRepository` | `get_upcoming`, `delete_all`, `create_batch` |
+| `IOracleRmanRepository` | `get_backup_jobs`, `get_running_jobs_count`, `get_backup_job_detail`, `get_backup_log` |
+
+### 2.3 Concrete Repositories — `coreRelback/gateways/repositories.py`
+
+| Class | Backend | Notes |
+|---|---|---|
+| `DjangoClientRepository` | Django ORM | Wraps `Client` model |
+| `DjangoHostRepository` | Django ORM | Wraps `Host` model |
+| `DjangoDatabaseRepository` | Django ORM | Wraps `Database` model |
+| `DjangoBackupPolicyRepository` | Django ORM | Wraps `BackupPolicy` model |
+| `DjangoScheduleRepository` | Django ORM | Wraps `Schedule` model |
+| `OracleRmanRepository` | python-oracledb | Queries Oracle RMAN Catalog views (`RC_RMAN_BACKUP_JOB_DETAILS`, `RC_RMAN_OUTPUT`); returns empty lists when `ORACLE_CATALOG` setting is `None` |
+| `DemoRmanRepository` | In-memory fixtures | Returns realistic fake RMAN data when `DEMO_MODE = True` in settings |
+
+### 2.4 Use Cases — `coreRelback/services/use_cases.py`
+
+One class per business action (Single Responsibility). Each constructor accepts interface types, never concrete classes.
+
+| Use Case | Purpose |
+|---|---|
+| `GetDashboardStatsUseCase` | Aggregates counts for Dashboard |
+| `GetScheduleReportUseCase` | Reads upcoming backup schedule by date range |
+| `GenerateScheduleUseCase` | Expands cron policy fields into `Schedule` rows |
+| `AuditBackupUseCase` | Correlates schedules with Oracle job results |
+| `GetBackupDetailUseCase` | Fetches RMAN log lines for a specific job |
+| `CreateClientUseCase` | Validates + creates a Client |
+| `UpdateClientUseCase` | Validates + updates a Client |
+| `DeleteClientUseCase` | Removes a Client |
+| `CreateHostUseCase` | Validates + creates a Host |
+| `UpdateHostUseCase` | Validates + updates a Host |
+| `DeleteHostUseCase` | Removes a Host |
+| `CreateDatabaseUseCase` | Validates + creates a Database |
+| `UpdateDatabaseUseCase` | Validates + updates a Database |
+| `DeleteDatabaseUseCase` | Removes a Database |
+| `CreateBackupPolicyUseCase` | Validates + creates a BackupPolicy |
+| `UpdateBackupPolicyUseCase` | Validates + updates a BackupPolicy |
+| `DeleteBackupPolicyUseCase` | Removes a BackupPolicy |
+
+### 2.5 Views — `coreRelback/views.py`
+
+Django views act as **HTTP adapters only**. They:
+1. Parse the HTTP request
+2. Instantiate concrete repositories and inject them into a use case
+3. Execute the use case
+4. Pass the returned entities to a template
+
+Views never contain business logic. They never call `Client.objects.filter(...)` directly.
+
+### 2.6 Oracle RMAN Gateway — `coreRelback/gateways/oracle_catalog.py`
+
+Implemented with `python-oracledb` in **Thin mode** (no Oracle Client required).  
+Connection target is configured via `settings.ORACLE_CATALOG`:
+
+```python
+ORACLE_CATALOG = {
+    "user": "rman_user",
+    "password": "...",
+    "dsn": "host:1521/CATALOG",
+}
+```
+
+When `ORACLE_CATALOG = None`, `OracleRmanRepository` returns empty lists — the UI renders an "Oracle catalog not available" banner without crashing.
+
+---
+
+## 3. Data Model
+
+```
+RelbackUser
+    │
+    └── created_by / updated_by (FK on all entities below)
+
+Client
+    ├── Host (FK: id_client)
+    │     └── Database (FK: id_client, id_host)
+    │           └── BackupPolicy (FK: id_client, id_host, id_database)
+    │                 └── Schedule (FK: id_policy)
+    │                 └── CronDay / CronHour / CronMinute / CronMonth / CronDayWeek / CronYear
+    └── BackupPolicy (FK: id_client)
+```
+
+### Key Models
+
+| Model | Table | Purpose |
+|---|---|---|
+| `RelbackUser` | `users` | Custom user — no AbstractBaseUser, own password hashing |
+| `Client` | `clients` | Organizational unit (customer / business unit) |
+| `Host` | `hosts` | Physical/virtual server running Oracle |
+| `Database` | `databases` | Oracle instance (identified by `dbid`) |
+| `BackupPolicy` | `backup_policies` | RMAN backup schedule definition |
+| `Schedule` | `schedules` | Expanded forecast entry (policy × time) |
+| `VwBackupPolicies` | `vw_backup_policies` | Oracle view, `managed=False` |
+
+---
+
+## 4. Authentication
+
+Custom session-based auth using `RelbackUser`. No Django `AbstractBaseUser`.
+
+| Component | Location |
+|---|---|
+| `RelbackBackend` | `coreRelback/backends.py` — custom auth backend |
+| `LoginView` | `coreRelback/views.py` |
+| `LogoutView` | `coreRelback/views.py` |
+| `RegisterView` | `coreRelback/views.py` |
+| `LoginRequiredMixin` | Applied to all CRUD views and dashboard |
+
+Session is stored in `django.contrib.sessions` (database-backed in production, file in dev).
+
+---
+
+## 5. Frontend Architecture
+
+```
+theme/                          ← Django app managed by django-tailwind
+  static_src/
+    src/styles.css              ← Entry point: @tailwind base/components/utilities
+    tailwind.config.js          ← DaisyUI plugin, relback_light/dark themes
+    package.json                ← tailwindcss 3.x, daisyui 4.x, autoprefixer
+  static/
+    css/dist/styles.css         ← Compiled output (minified, ~100 KB)
+
+coreRelback/templates/
+  base.html                     ← DaisyUI drawer layout, theme switcher
+  index.html                    ← Dashboard: DaisyUI stats component
+  reports.html                  ← RMAN job table + badge status
+  reportsReadLog.html           ← RMAN log detail lines
+  clients.html / hosts.html … ← CRUD list views
+  *_form.html                   ← DaisyUI form-control inputs
+  auth/login.html               ← DaisyUI card form
+```
+
+### DaisyUI Theme Tokens
+
+| Token | relback\_dark | Purpose |
+|---|---|---|
+| `primary` | `#C74634` | Oracle Red — buttons, badges |
+| `base-100` | `#0f172a` | Page background |
+| `success` | `#16a34a` | COMPLETED status |
+| `error` | `#dc2626` | FAILED status |
+| `warning` | `#d97706` | WARNING / RUNNING\_WITH\_ISSUES |
+| `info` | `#2563eb` | RUNNING status |
+| `neutral` | `#334155` | UNKNOWN / headers |
+
+---
+
+## 6. CI Pipeline
+
+```
+.github/workflows/ci.yml
+  ├── check-and-test       Gate 1: django check | Gate 2: 46 domain tests | Gate 3: 37 integration tests
+  ├── sql-lint             sqlfluff lint databaseProject/ (config: .sqlfluff, exclusions: .sqlfluffignore)
+  ├── template-lint        djlint coreRelback/templates/ --lint (config: .djlintrc)
+  └── tailwind-build       npm ci + npm run build → CSS > 1 KB assertion
+```
+
+### Test Modules
+
+| Module | Count | DB required | Purpose |
+|---|---|---|---|
+| `coreRelback.tests_domain` | 46 | No | Pure domain: entities, use cases, schedule expansion, RMAN parsing |
+| `coreRelback.tests` | 37 | Yes (SQLite) | Integration: views, auth, HTTP status codes |
+
+---
+
+## 7. Configuration Files
+
+| File | Purpose |
+|---|---|
+| `projectRelback/settings.py` | Production settings (Oracle, Tailwind app) |
+| `projectRelback/settings_dev.py` | Development: SQLite, `DEBUG=True`, `ORACLE_CATALOG=None` |
+| `projectRelback/settings_test.py` | CI integration tests: SQLite in-memory |
+| `.sqlfluff` | sqlfluff dialect + excluded rules |
+| `.sqlfluffignore` | Oracle PL/SQL files excluded from lint |
+| `.djlintrc` | djlint profile=django, enforces T003 |
+| `.prettierignore` | Prevents Prettier from formatting Django templates |
+
+---
+
+## 8. Management Commands
+
+| Command | Module | Purpose |
+|---|---|---|
+| `python manage.py tailwind install` | django-tailwind | Install npm dependencies |
+| `python manage.py tailwind build` | django-tailwind | Compile Tailwind CSS (production) |
+| `python manage.py tailwind start` | django-tailwind | Watch mode (development) |
+| `python manage.py seed_demo` | `coreRelback/management/commands/seed_demo.py` | Populate SQLite with realistic demo data (clients, hosts, databases, policies, simulated RMAN jobs) |
+
+---
+
+## 9. Project Structure
+
+```
+relback/
+├── coreRelback/
+│   ├── domain/
+│   │   └── entities.py          ← Pure domain entities / value objects
+│   ├── gateways/
+│   │   ├── interfaces.py        ← Abstract ports (IClientRepository, IOracleRmanRepository…)
+│   │   ├── repositories.py      ← Django ORM adapters + DemoRmanRepository
+│   │   └── oracle_catalog.py    ← python-oracledb adapter
+│   ├── services/
+│   │   └── use_cases.py         ← All business interactors
+│   ├── management/commands/
+│   │   └── seed_demo.py         ← Demo data seeder
+│   ├── templates/               ← Django HTML templates
+│   ├── models.py                ← Django ORM models (outer layer)
+│   ├── views.py                 ← HTTP adapter (thin — delegates to use cases)
+│   └── urls.py
+├── projectRelback/
+│   ├── settings.py              ← Production settings
+│   ├── settings_dev.py          ← Development settings
+│   └── settings_test.py         ← Test settings
+├── theme/                       ← django-tailwind app
+│   └── static_src/              ← Tailwind + DaisyUI build chain
+├── databaseProject/             ← Oracle DDL / migration scripts
+├── docs/                        ← Architecture + Roadmap docs
+├── .sqlfluff / .djlintrc        ← Lint configs
+└── .github/workflows/ci.yml     ← CI pipeline
+```

--- a/docs/ROADMAP_TAILWIND_DAISYUI.md
+++ b/docs/ROADMAP_TAILWIND_DAISYUI.md
@@ -20,12 +20,19 @@ nvm install --lts
 
 ## Phase Overview
 
-| Phase | Name | Status |
-|---|---|---|
-| 1 | Setup — Infrastructure | ✅ Done (Issue #12, PR #13) |
-| 2 | Theme — DaisyUI + Design Tokens | 🔲 Pending |
-| 3 | Base Layout Migration | 🔲 Pending |
-| 4 | Component Migration (Dashboard, Tables) | 🔲 Pending |
+| Phase | Name                                      | Status         | PR                    |
+| ----- | ----------------------------------------- | -------------- | --------------------- |
+| 1     | Setup — Infrastructure                    | ✅ Done        | #13                   |
+| 2     | Theme — DaisyUI + Design Tokens           | ✅ Done        | #17                   |
+| 3     | Base Layout Migration                     | ✅ Done        | #21                   |
+| 4     | Component Migration (Dashboard, Tables)   | ✅ Done        | #23 / #25 / #27 / #29 |
+| 5     | Remaining Templates + Auth                | ✅ Done        | #31                   |
+| 6     | Live Oracle RMAN Gateway                  | ✅ Done        | #34                   |
+| 7     | Oracle Reports — UI Enhancements          | ✅ Done        | #36                   |
+| 8     | Report Log Detail View                    | ✅ Done        | #38                   |
+| 9     | CI — Hardening & Quality Gates            | ✅ Done        | #42 / #44             |
+| 10    | Demo Mode — Seed data for local preview   | 🚧 In Progress | —                     |
+| 11    | Production Deployment (Docker + Gunicorn) | 🔲 Pending     | —                     |
 
 ---
 
@@ -33,17 +40,18 @@ nvm install --lts
 
 **Goal:** Get `django-tailwind` wired into Django. After this phase, running `python manage.py tailwind start` produces a compiled `theme.css`.
 
-| # | Task | Files Impacted | Sensor |
-|---|---|---|---|
-| 1.1 | Install `django-tailwind[reload]` and add to `requirements.txt` | `requirements.txt` | `pip install -r requirements.txt` → exit 0 |
-| 1.2 | Add `tailwind` and `theme` to `INSTALLED_APPS`; set `TAILWIND_APP_NAME`, `INTERNAL_IPS`, `NPM_BIN_PATH` | `projectRelback/settings.py` | `python manage.py check` |
-| 1.3 | Scaffold `theme/` app via `manage.py tailwind init` | `theme/` (new Django app) | Directory exists; `python manage.py check` |
-| 1.4 | Add DaisyUI to `theme/static_src/package.json` | `theme/static_src/package.json` | `cat theme/static_src/package.json` shows `daisyui` |
-| 1.5 | Configure `tailwind.config.js` — content paths, DaisyUI plugin, Relback themes | `theme/static_src/tailwind.config.js` | `cat theme/static_src/tailwind.config.js` |
-| 1.6 | Run `python manage.py tailwind install` (requires Node ≥ 18) | `theme/static_src/node_modules/` | Exit 0 — `node_modules` is created |
-| 1.7 | Load `{% tailwind_css %}` tag in `base.html` | `coreRelback/templates/base.html` | Page renders without 404 on CSS |
+| #   | Task                                                                                                    | Files Impacted                        | Sensor                                              |
+| --- | ------------------------------------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------- |
+| 1.1 | Install `django-tailwind[reload]` and add to `requirements.txt`                                         | `requirements.txt`                    | `pip install -r requirements.txt` → exit 0          |
+| 1.2 | Add `tailwind` and `theme` to `INSTALLED_APPS`; set `TAILWIND_APP_NAME`, `INTERNAL_IPS`, `NPM_BIN_PATH` | `projectRelback/settings.py`          | `python manage.py check`                            |
+| 1.3 | Scaffold `theme/` app via `manage.py tailwind init`                                                     | `theme/` (new Django app)             | Directory exists; `python manage.py check`          |
+| 1.4 | Add DaisyUI to `theme/static_src/package.json`                                                          | `theme/static_src/package.json`       | `cat theme/static_src/package.json` shows `daisyui` |
+| 1.5 | Configure `tailwind.config.js` — content paths, DaisyUI plugin, Relback themes                          | `theme/static_src/tailwind.config.js` | `cat theme/static_src/tailwind.config.js`           |
+| 1.6 | Run `python manage.py tailwind install` (requires Node ≥ 18)                                            | `theme/static_src/node_modules/`      | Exit 0 — `node_modules` is created                  |
+| 1.7 | Load `{% tailwind_css %}` tag in `base.html`                                                            | `coreRelback/templates/base.html`     | Page renders without 404 on CSS                     |
 
 **First commit after Phase 1:**
+
 ```
 feat(ui): bootstrap django-tailwind + DaisyUI theme app (#12)
 ```
@@ -56,13 +64,13 @@ feat(ui): bootstrap django-tailwind + DaisyUI theme app (#12)
 
 ### Backup Status Color Palette
 
-| Status | Semantic | DaisyUI Token | Hex |
-|---|---|---|---|
-| `COMPLETED` | Success | `success` | `#22c55e` (green-500) |
-| `RUNNING` | Info | `info` | `#3b82f6` (blue-500) |
-| `FAILED` | Error | `error` | `#ef4444` (red-500) |
-| `RUNNING_WITH_ISSUES` | Warning | `warning` | `#f59e0b` (amber-500) |
-| `UNKNOWN` | Neutral | `neutral` | `#6b7280` (gray-500) |
+| Status                | Semantic | DaisyUI Token | Hex                   |
+| --------------------- | -------- | ------------- | --------------------- |
+| `COMPLETED`           | Success  | `success`     | `#22c55e` (green-500) |
+| `RUNNING`             | Info     | `info`        | `#3b82f6` (blue-500)  |
+| `FAILED`              | Error    | `error`       | `#ef4444` (red-500)   |
+| `RUNNING_WITH_ISSUES` | Warning  | `warning`     | `#f59e0b` (amber-500) |
+| `UNKNOWN`             | Neutral  | `neutral`     | `#6b7280` (gray-500)  |
 
 ### DaisyUI Custom Theme (`tailwind.config.js` excerpt)
 
@@ -99,11 +107,11 @@ daisyui: {
 },
 ```
 
-| # | Task | Files Impacted | Sensor |
-|---|---|---|---|
-| 2.1 | Define Relback color tokens and DaisyUI theme objects | `theme/static_src/tailwind.config.js` | `python manage.py tailwind build` → exit 0 |
-| 2.2 | Add theme switcher (light/dark/dracula) via `data-theme` attribute on `<html>` | `base.html`, `theme/static_src/src/styles.css` | Visual: theme toggle changes colors |
-| 2.3 | Tag `BackupStatusValue` enum display in template with status-to-badge mapping | `coreRelback/templates/reports.html` | `python manage.py test coreRelback.tests` |
+| #   | Task                                                                           | Files Impacted                                 | Sensor                                     |
+| --- | ------------------------------------------------------------------------------ | ---------------------------------------------- | ------------------------------------------ |
+| 2.1 | Define Relback color tokens and DaisyUI theme objects                          | `theme/static_src/tailwind.config.js`          | `python manage.py tailwind build` → exit 0 |
+| 2.2 | Add theme switcher (light/dark/dracula) via `data-theme` attribute on `<html>` | `base.html`, `theme/static_src/src/styles.css` | Visual: theme toggle changes colors        |
+| 2.3 | Tag `BackupStatusValue` enum display in template with status-to-badge mapping  | `coreRelback/templates/reports.html`           | `python manage.py test coreRelback.tests`  |
 
 ---
 
@@ -122,13 +130,13 @@ daisyui: {
 └─────────────────────────────────────────────────────┘
 ```
 
-| # | Task | Files Impacted | Sensor |
-|---|---|---|---|
-| 3.1 | Rewrite `base.html` structure with DaisyUI `drawer` component | `coreRelback/templates/base.html` | `python manage.py test coreRelback.tests` — 20 tests pass |
-| 3.2 | Migrate navbar links to sidebar `<ul class="menu">` | `base.html` | Visual: links render with hover states |
-| 3.3 | Migrate user dropdown to `<div class="dropdown dropdown-end">` | `base.html` | Logout POST still works |
-| 3.4 | Add breadcrumbs component to page title bar | `base.html` | `python manage.py check` |
-| 3.5 | Migrate `auth/login.html` and `auth/register.html` to Tailwind | `coreRelback/templates/auth/*.html` | `python manage.py test coreRelback.tests` |
+| #   | Task                                                           | Files Impacted                      | Sensor                                                    |
+| --- | -------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------- |
+| 3.1 | Rewrite `base.html` structure with DaisyUI `drawer` component  | `coreRelback/templates/base.html`   | `python manage.py test coreRelback.tests` — 20 tests pass |
+| 3.2 | Migrate navbar links to sidebar `<ul class="menu">`            | `base.html`                         | Visual: links render with hover states                    |
+| 3.3 | Migrate user dropdown to `<div class="dropdown dropdown-end">` | `base.html`                         | Logout POST still works                                   |
+| 3.4 | Add breadcrumbs component to page title bar                    | `base.html`                         | `python manage.py check`                                  |
+| 3.5 | Migrate `auth/login.html` and `auth/register.html` to Tailwind | `coreRelback/templates/auth/*.html` | `python manage.py test coreRelback.tests`                 |
 
 ---
 
@@ -143,13 +151,13 @@ daisyui: {
 3. **CRUD Lists** (`clients.html`, `hosts.html`, `databases.html`, `policies.html`) — DaisyUI `table` with row actions
 4. **CRUD Forms** — DaisyUI `form-control` + `label` + `input`/`select`
 
-| # | Task | Files Impacted | Sensor |
-|---|---|---|---|
-| 4.1 | Dashboard stats cards with `stats` component | `templates/index.html` | Visual + `python manage.py test` |
-| 4.2 | Reports table + `badge` for `BackupStatusValue` | `templates/reports.html` | All 20 tests pass |
-| 4.3 | CRUD list views with DaisyUI `table` | `templates/clients.html`, `hosts.html`, `databases.html`, `policies.html` | All 20 tests pass |
-| 4.4 | CRUD forms with DaisyUI `form-control` | `templates/*_form.html`, `templates/*_confirm_delete.html` | All 20 tests pass |
-| 4.5 | Auth pages (login/register) with DaisyUI `card` + `form-control` | `templates/auth/login.html`, `register.html` | `LoginViewTests` + `LogoutRegisterTests` pass |
+| #   | Task                                                             | Files Impacted                                                            | Sensor                                        |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------- |
+| 4.1 | Dashboard stats cards with `stats` component                     | `templates/index.html`                                                    | Visual + `python manage.py test`              |
+| 4.2 | Reports table + `badge` for `BackupStatusValue`                  | `templates/reports.html`                                                  | All 20 tests pass                             |
+| 4.3 | CRUD list views with DaisyUI `table`                             | `templates/clients.html`, `hosts.html`, `databases.html`, `policies.html` | All 20 tests pass                             |
+| 4.4 | CRUD forms with DaisyUI `form-control`                           | `templates/*_form.html`, `templates/*_confirm_delete.html`                | All 20 tests pass                             |
+| 4.5 | Auth pages (login/register) with DaisyUI `card` + `form-control` | `templates/auth/login.html`, `register.html`                              | `LoginViewTests` + `LogoutRegisterTests` pass |
 
 ---
 
@@ -170,11 +178,94 @@ python manage.py tailwind install
 
 ## Files Created / Modified by Phase 1
 
-| File | Action |
-|---|---|
-| `requirements.txt` | Add `django-tailwind[reload]>=3.8.0,<4.0` |
-| `projectRelback/settings.py` | Add `tailwind`, `theme` to `INSTALLED_APPS`; `TAILWIND_APP_NAME`, `INTERNAL_IPS`, `NPM_BIN_PATH` |
-| `theme/` | New Django app (scaffolded by `manage.py tailwind init`) |
-| `theme/static_src/tailwind.config.js` | DaisyUI plugin + content paths + Relback themes |
-| `theme/static_src/package.json` | `daisyui` added as dependency |
-| `coreRelback/templates/base.html` | Add `{% load tailwind_tags %}` + `{% tailwind_css %}` |
+| File                                  | Action                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `requirements.txt`                    | Add `django-tailwind[reload]>=3.8.0,<4.0`                                                        |
+| `projectRelback/settings.py`          | Add `tailwind`, `theme` to `INSTALLED_APPS`; `TAILWIND_APP_NAME`, `INTERNAL_IPS`, `NPM_BIN_PATH` |
+| `theme/`                              | New Django app (scaffolded by `manage.py tailwind init`)                                         |
+| `theme/static_src/tailwind.config.js` | DaisyUI plugin + content paths + Relback themes                                                  |
+| `theme/static_src/package.json`       | `daisyui` added as dependency                                                                    |
+| `coreRelback/templates/base.html`     | Add `{% load tailwind_tags %}` + `{% tailwind_css %}`                                            |
+
+---
+
+## CI Quality Gates (active on every PR)
+
+| Job | Tool | What it enforces |
+|---|---|---|
+| `check-and-test` | Django + pytest | System check, 46 domain tests, 37 integration tests |
+| `sql-lint` | sqlfluff 3+ | SQL hygiene in `databaseProject/` — exits non-zero on violations |
+| `template-lint` | djlint 1.36+ | Named endblocks, no collapsed `{% block %}` tags (T003) |
+| `tailwind-build` | Node 20 + npm | Compiled `theme/static/css/dist/styles.css` > 1 KB |
+
+Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
+
+---
+
+## Completed Delivery History
+
+| PR | Issue | Type | Description |
+|---|---|---|---|
+| #2 | #1 | refactor | Initial Clean Architecture — CRUD use cases, entities, repositories |
+| #5 | #4 | feat | LoginRequiredMixin on all CRUD views |
+| #7 | #6 | chore | Remove EOL Angular.js + Materialize CSS |
+| #9 | #8 | fix | Integration tests after auth gates |
+| #11 | #10 | feat | Login / logout / register views wired |
+| #13 | #12 | feat | Tailwind CSS + DaisyUI Phase 1 — infrastructure |
+| #15 | #14 | feat | Phase 1 hardening — CSS guard, WCAG tokens, CI Tailwind build gate |
+| #17 | #16 | feat | Phase 2 — DaisyUI status badges + theme switcher |
+| #19 | #18 | chore | Commit package-lock.json + formatter normalisation |
+| #21 | #20 | feat | Phase 3 — DaisyUI drawer layout + auth templates |
+| #23 | #22 | feat | Phase 4.1 — Dashboard stats with DaisyUI `stats` |
+| #25 | #24 | feat | Phase 4.2 — Reports table + `badge` for backup status |
+| #27 | #26 | feat | Phase 4.3 — CRUD list views with DaisyUI `table` |
+| #29 | #28 | feat | Phase 4.4 — CRUD forms with DaisyUI `form-control` |
+| #31 | #30 | feat | Phase 5 — remaining templates + creators page |
+| #34 | #33 | feat | Live Oracle RMAN Catalog gateway + graceful fallback |
+| #36 | #35 | feat | Reports UI — oracle-available banner + running_jobs |
+| #38 | #37 | feat | Report log detail view (RC_RMAN_OUTPUT) |
+| #40 | #39 | fix | Template formatter regression hotfix |
+| #42 | #41 | ci | sqlfluff hardening — remove `|| true` |
+| #44 | #43 | ci | djlint template-lint gate + named endblocks |
+
+
+---
+
+## CI Quality Gates (active on every PR)
+
+| Job | Tool | What it enforces |
+|---|---|---|
+| `check-and-test` | Django + pytest | System check, 46 domain tests, 37 integration tests |
+| `sql-lint` | sqlfluff 3+ | SQL hygiene in `databaseProject/` — exits non-zero on violations |
+| `template-lint` | djlint 1.36+ | Named endblocks, no collapsed `{% block %}` tags (T003) |
+| `tailwind-build` | Node 20 + npm | Compiled `theme/static/css/dist/styles.css` > 1 KB |
+
+Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
+
+---
+
+## Completed Delivery History
+
+| PR | Issue | Type | Description |
+|---|---|---|---|
+| #2 | #1 | refactor | Initial Clean Architecture — CRUD use cases, entities, repositories |
+| #5 | #4 | feat | LoginRequiredMixin on all CRUD views |
+| #7 | #6 | chore | Remove EOL Angular.js + Materialize CSS |
+| #9 | #8 | fix | Integration tests after auth gates |
+| #11 | #10 | feat | Login / logout / register views wired |
+| #13 | #12 | feat | Tailwind CSS + DaisyUI Phase 1 — infrastructure |
+| #15 | #14 | feat | Phase 1 hardening — CSS guard, WCAG tokens, CI Tailwind build gate |
+| #17 | #16 | feat | Phase 2 — DaisyUI status badges + theme switcher |
+| #19 | #18 | chore | Commit package-lock.json + formatter normalisation |
+| #21 | #20 | feat | Phase 3 — DaisyUI drawer layout + auth templates |
+| #23 | #22 | feat | Phase 4.1 — Dashboard stats with DaisyUI `stats` |
+| #25 | #24 | feat | Phase 4.2 — Reports table + badge for backup status |
+| #27 | #26 | feat | Phase 4.3 — CRUD list views with DaisyUI table |
+| #29 | #28 | feat | Phase 4.4 — CRUD forms with DaisyUI form-control |
+| #31 | #30 | feat | Phase 5 — remaining templates + creators page |
+| #34 | #33 | feat | Live Oracle RMAN Catalog gateway + graceful fallback |
+| #36 | #35 | feat | Reports UI — oracle-available banner + running_jobs |
+| #38 | #37 | feat | Report log detail view (RC_RMAN_OUTPUT) |
+| #40 | #39 | fix | Template formatter regression hotfix |
+| #42 | #41 | ci | sqlfluff hardening — remove `|| true` |
+| #44 | #43 | ci | djlint template-lint gate + named endblocks |

--- a/projectRelback/settings_local.py
+++ b/projectRelback/settings_local.py
@@ -1,0 +1,30 @@
+"""
+Local development settings — SQLite file DB + Demo Mode.
+
+Use this when you don't have Oracle available but want to run the full
+web interface with realistic fake data.
+
+Usage:
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py migrate
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py seed_demo
+    DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py runserver
+"""
+from projectRelback.settings_dev import *  # noqa: F401, F403
+
+# File-based SQLite (persists between server restarts)
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+# Bypass Oracle-specific migrations (sequences/triggers — not supported by SQLite)
+MIGRATION_MODULES = {
+    "coreRelback": None,
+}
+
+# Demo mode: OracleRmanRepository is replaced by DemoRmanRepository in views.
+# This populates the Reports and Log Detail pages with realistic fixture data.
+DEMO_MODE = True
+ORACLE_CATALOG = None


### PR DESCRIPTION
Closes #45

## Changes

### New: `projectRelback/settings_local.py`
SQLite file-based DB + `DEMO_MODE=True` + `ORACLE_CATALOG=None`. Use for local preview without Oracle.

### New: `coreRelback/management/commands/seed_demo.py`
Populates the database with: 4 clients, 8 hosts, 8 Oracle databases, 8 backup policies, 1 admin user (admin/demo1234). Idempotent — safe to run multiple times. Supports `--flush` to wipe and reseed.

### New: `DemoRmanRepository` (appended to `repositories.py`)
Implements `IOracleRmanRepository`. Returns 30 realistic RMAN backup jobs (mix of COMPLETED/FAILED/WARNING/RUNNING statuses, 5 databases, DISK+SBT_TAPE devices). Also returns a sample `get_backup_log` output matching real RMAN console format.

### Updated: `coreRelback/views.py`
Added `_get_rman_repo()` factory — returns `DemoRmanRepository` when `DEMO_MODE=True`, else `OracleRmanRepository`. Both `reports` and `report_read_log_detail` views updated.

### New: `docs/ARCHITECTURE.md`
Full system architecture document covering all layers, entities, repositories, use cases, views, auth, frontend, CI, and project structure.

### Updated: `docs/ROADMAP_TAILWIND_DAISYUI.md`
All phases marked complete, CI quality gates table added, full delivery history (PRs #2–#44) appended.

## Quick Start (local demo)

```bash
DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py migrate --run-syncdb
DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py seed_demo
DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py runserver
# http://localhost:8000  —  Login: admin / demo1234
```

## Sensor Gates

- ✅ Gate 1: `django check` — 0 issues
- ✅ Gate 2: 46 domain tests — OK
- ✅ Gate 3: 37 integration tests — OK