### PR TITLE
[DOCS] Update ARCHITECTURE and ROADMAP — phases 10/11 + Phase 12+ future roadmap

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,15 +231,21 @@ coreRelback/templates/
 
 ### DaisyUI Theme Tokens
 
-| Token | relback\_dark | Purpose |
-|---|---|---|
-| `primary` | `#C74634` | Oracle Red — buttons, badges |
-| `base-100` | `#0f172a` | Page background |
-| `success` | `#16a34a` | COMPLETED status |
-| `error` | `#dc2626` | FAILED status |
-| `warning` | `#d97706` | WARNING / RUNNING\_WITH\_ISSUES |
-| `info` | `#2563eb` | RUNNING status |
-| `neutral` | `#334155` | UNKNOWN / headers |
+| Token | relback\_light | relback\_dark | Purpose |
+|---|---|---|---|
+| `primary` | `#C74634` | `#6366f1` | Buttons, active elements (Oracle Red / Indigo-500) |
+| `secondary` | `#1A1A2E` | `#94a3b8` | Secondary labels, muted text |
+| `accent` | `#0052CC` | `#06b6d4` | Accent highlights (Oracle Blue / Cyan-500) |
+| `base-100` | `#f8fafc` | `#0f172a` | Page background |
+| `base-200` | _(default)_ | `#1e293b` | Cards, sidebar |
+| `base-300` | _(default)_ | `#334155` | Borders, dividers |
+| `success` | `#22c55e` | `#4ade80` | COMPLETED status (WCAG AA ≥4.5:1 on dark bg) |
+| `warning` | `#f59e0b` | `#fbbf24` | WARNING / RUNNING\_WITH\_ISSUES |
+| `error` | `#ef4444` | `#f87171` | FAILED status |
+| `info` | `#3b82f6` | `#93c5fd` | RUNNING status |
+| `neutral` | `#1e293b` | `#334155` | UNKNOWN / headers |
+
+> Dark theme uses lighter status colors (400-series instead of 600-series) to meet WCAG AA contrast ratio ≥4.5:1 against `#0f172a` background — critical for NOC/operations monitor readability.
 
 ---
 
@@ -264,15 +270,22 @@ coreRelback/templates/
 
 ## 7. Configuration Files
 
+| File | Use case | Oracle | DEMO\_MODE |
+|---|---|---|---|
+| `projectRelback/settings.py` | Base (not used directly) | hardcoded | off |
+| `projectRelback/settings_dev.py` | Dev — `DATABASES={}`, `DEBUG=True` | off | off |
+| `projectRelback/settings_local.py` | Local UI: SQLite file db + realistic mock RMAN data | off | on |
+| `projectRelback/settings_test.py` | CI integration tests: SQLite in-memory | off | off |
+| `projectRelback/settings_prod.py` | Production/Docker: `DEBUG=False`, WhiteNoise, all config from env vars | env vars | auto |
+
 | File | Purpose |
 |---|---|
-| `projectRelback/settings.py` | Production settings (Oracle, Tailwind app) |
-| `projectRelback/settings_dev.py` | Development: SQLite, `DEBUG=True`, `ORACLE_CATALOG=None` |
-| `projectRelback/settings_test.py` | CI integration tests: SQLite in-memory |
 | `.sqlfluff` | sqlfluff dialect + excluded rules |
 | `.sqlfluffignore` | Oracle PL/SQL files excluded from lint |
-| `.djlintrc` | djlint profile=django, enforces T003 |
+| `.djlintrc` | djlint profile=django, enforces T003 (named endblocks) |
 | `.prettierignore` | Prevents Prettier from formatting Django templates |
+| `.env.example` | Documented env var template — `DJANGO_SECRET_KEY`, `ALLOWED_HOSTS`, `DB_*`, `ORACLE_CATALOG_*`, `GUNICORN_WORKERS` |
+| `.dockerignore` | Lean Docker build context — excludes `.venv/`, `__pycache__/`, `db.sqlite3`, `.git/` |
 
 ---
 
@@ -283,11 +296,56 @@ coreRelback/templates/
 | `python manage.py tailwind install` | django-tailwind | Install npm dependencies |
 | `python manage.py tailwind build` | django-tailwind | Compile Tailwind CSS (production) |
 | `python manage.py tailwind start` | django-tailwind | Watch mode (development) |
-| `python manage.py seed_demo` | `coreRelback/management/commands/seed_demo.py` | Populate SQLite with realistic demo data (clients, hosts, databases, policies, simulated RMAN jobs) |
+| `python manage.py seed_demo` | `coreRelback/management/commands/seed_demo.py` | Populate SQLite with realistic demo data (4 clients, 8 hosts, 8 databases, 8 policies, simulated RMAN jobs). Supports `--flush` flag. |
 
 ---
 
-## 9. Project Structure
+## 9. Production Deployment
+
+### Stack
+
+| Component | Version | Role |
+|---|---|---|
+| Gunicorn | 25.x | WSGI application server |
+| WhiteNoise | 6.x | Compressed static file serving (no Nginx needed for small deployments) |
+| Docker | multi-stage | Node 20 CSS builder + Python 3.13 runtime |
+
+### Dockerfile (multi-stage)
+
+```
+Stage 1 (css-builder)   node:20-slim
+  npm ci + npm run build → theme/static/css/dist/styles.css
+
+Stage 2 (runtime)       python:3.13-slim
+  pip install requirements.txt
+  collectstatic → STATIC_ROOT
+  useradd relback (non-root)
+  CMD: gunicorn projectRelback.wsgi --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-3}
+```
+
+### Environment Variables (production)
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `DJANGO_SECRET_KEY` | Yes | — | No unsafe fallback in prod |
+| `ALLOWED_HOSTS` | Yes | `localhost,127.0.0.1` | Comma-separated |
+| `DB_ENGINE` | No | sqlite3 | `django.db.backends.oracle` for Oracle |
+| `DB_NAME` / `DB_USER` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` | If Oracle | — | Oracle credentials |
+| `ORACLE_CATALOG_USER` / `ORACLE_CATALOG_PASSWORD` / `ORACLE_CATALOG_DSN` | If Oracle | — | RMAN catalog connection; empty → `DEMO_MODE=True` |
+| `GUNICORN_WORKERS` | No | 3 | `(2 * CPU) + 1` is standard |
+
+### Quick Start
+
+```bash
+cp .env.example .env        # fill DJANGO_SECRET_KEY at minimum
+docker compose up --build   # http://localhost:8000
+docker compose exec web python manage.py seed_demo  # optional demo data
+# Login: admin / demo1234
+```
+
+---
+
+## 10. Project Structure
 
 ```
 relback/
@@ -297,23 +355,34 @@ relback/
 │   ├── gateways/
 │   │   ├── interfaces.py        ← Abstract ports (IClientRepository, IOracleRmanRepository…)
 │   │   ├── repositories.py      ← Django ORM adapters + DemoRmanRepository
-│   │   └── oracle_catalog.py    ← python-oracledb adapter
+│   │   └── oracle_catalog.py    ← python-oracledb adapter (Thin mode)
 │   ├── services/
 │   │   └── use_cases.py         ← All business interactors
 │   ├── management/commands/
-│   │   └── seed_demo.py         ← Demo data seeder
-│   ├── templates/               ← Django HTML templates
+│   │   └── seed_demo.py         ← Demo data seeder (idempotent, --flush flag)
+│   ├── templates/               ← Django HTML templates (DaisyUI components)
 │   ├── models.py                ← Django ORM models (outer layer)
 │   ├── views.py                 ← HTTP adapter (thin — delegates to use cases)
 │   └── urls.py
 ├── projectRelback/
-│   ├── settings.py              ← Production settings
-│   ├── settings_dev.py          ← Development settings
-│   └── settings_test.py         ← Test settings
+│   ├── settings.py              ← Base settings
+│   ├── settings_dev.py          ← Dev: DATABASES={}, DEBUG=True
+│   ├── settings_local.py        ← Local: SQLite file + DEMO_MODE=True
+│   ├── settings_test.py         ← CI: SQLite in-memory
+│   └── settings_prod.py         ← Production: DEBUG=False, WhiteNoise, env-based
 ├── theme/                       ← django-tailwind app
 │   └── static_src/              ← Tailwind + DaisyUI build chain
+│       ├── tailwind.config.js   ← DaisyUI themes: relback_light + relback_dark
+│       └── src/styles.css       ← @tailwind base/components/utilities entry point
 ├── databaseProject/             ← Oracle DDL / migration scripts
-├── docs/                        ← Architecture + Roadmap docs
+├── docs/
+│   ├── ARCHITECTURE.md          ← This document
+│   ├── ROADMAP_TAILWIND_DAISYUI.md
+│   └── UX_UI_analysis.md
+├── Dockerfile                   ← Multi-stage (Node 20 CSS + Python 3.13 Gunicorn)
+├── docker-compose.yml           ← One-command production preview
+├── .env.example                 ← Env var template (commit safe — no real values)
+├── .dockerignore
 ├── .sqlfluff / .djlintrc        ← Lint configs
-└── .github/workflows/ci.yml     ← CI pipeline
+└── .github/workflows/ci.yml     ← CI pipeline (check + tests + lint + docker build)
 ```

--- a/docs/ROADMAP_TAILWIND_DAISYUI.md
+++ b/docs/ROADMAP_TAILWIND_DAISYUI.md
@@ -90,15 +90,15 @@ daisyui: {
         "info":      "#3b82f6",
       },
       relback_dark: {
-        "primary":   "#C74634",
-        "secondary": "#e2e8f0",
-        "accent":    "#60a5fa",
+        "primary":   "#6366f1",   // indigo-500 — modern corporate  (PR #48)
+        "secondary": "#94a3b8",   // slate-400 — muted label text
+        "accent":    "#06b6d4",   // cyan-500  — tech/monitoring accent
         "neutral":   "#334155",
-        "base-100":  "#0f172a",
-        "success":   "#16a34a",
-        "warning":   "#d97706",
-        "error":     "#dc2626",
-        "info":      "#2563eb",
+        "base-100":  "#0f172a",   // slate-950
+        "success":   "#4ade80",   // green-400 — WCAG AA ≥4.5:1 on dark bg
+        "warning":   "#fbbf24",   // amber-400
+        "error":     "#f87171",   // red-400
+        "info":      "#93c5fd",   // blue-300
       },
     },
     "dracula",
@@ -189,6 +189,76 @@ python manage.py tailwind install
 
 ---
 
+## Phase 5 — Remaining Templates + Auth
+
+**Goal:** Complete template migration for all remaining pages not covered in Phase 4.
+
+| # | Task | Files Impacted | Sensor |
+|---|---|---|---|
+| 5.1 | Migrate `creators.html` to DaisyUI `table` | `templates/creators.html` | All tests pass |
+| 5.2 | Migrate confirm-delete dialogs to DaisyUI `modal` | `templates/*_confirm_delete.html` | All tests pass |
+| 5.3 | Migrate `user_settings.html` to DaisyUI `form-control` | `templates/user_settings.html` | Functional test |
+| 5.4 | Apply `relback_light` + `relback_dark` + theme switcher across all pages | `base.html` | Visual test |
+
+---
+
+## Phase 10 — Demo Mode
+
+**Goal:** Enable standalone UI preview without Oracle connection — seed realistic RMAN data into SQLite.
+
+| # | Task | Files Impacted | Sensor |
+|---|---|---|---|
+| 10.1 | Create `DemoRmanRepository` — in-memory fixture data | `coreRelback/gateways/repositories.py` | Unit test of fixture data shape |
+| 10.2 | Create `seed_demo` management command — 4 clients, 8 hosts, 8 databases, 8 policies | `coreRelback/management/commands/seed_demo.py` | `python manage.py seed_demo` exits 0 |
+| 10.3 | Create `settings_local.py` — SQLite file DB + `DEMO_MODE=True` | `projectRelback/settings_local.py` | `python manage.py check --settings=projectRelback.settings_local` exits 0 |
+| 10.4 | Wire `_get_rman_repo()` factory in `views.py` — returns `DemoRmanRepository` when `DEMO_MODE=True` | `coreRelback/views.py` | Reports page renders with demo data |
+
+**Quick Start (demo mode):**
+
+```bash
+rm -f db.sqlite3
+DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py migrate --run-syncdb
+DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py seed_demo
+DJANGO_SETTINGS_MODULE=projectRelback.settings_local python manage.py runserver
+# Login: admin / demo1234
+```
+
+---
+
+## Phase 11 — Production Deployment (Docker + Gunicorn)
+
+**Goal:** Ship a production-ready container — `docker compose up --build` serves the full app.
+
+| # | Task | Files Impacted | Sensor |
+|---|---|---|---|
+| 11.1 | Add `gunicorn>=21.2,<23.0` + `whitenoise>=6.6,<7.0` to requirements | `requirements.txt` | `pip install -r requirements.txt` exits 0 |
+| 11.2 | Create `settings_prod.py` — `DEBUG=False`, WhiteNoise storage, env-based config, DEMO_MODE auto-detect | `projectRelback/settings_prod.py` | `django check --settings=...settings_prod` → 0 issues |
+| 11.3 | Create multi-stage `Dockerfile` — Stage 1: Node 20 CSS builder; Stage 2: Python 3.13 Gunicorn runtime | `Dockerfile` | `docker build .` exits 0 |
+| 11.4 | Create `docker-compose.yml` — mounts SQLite volume, loads `.env` | `docker-compose.yml` | `docker compose config` exits 0 |
+| 11.5 | Create `.env.example` — documents all env vars | `.env.example` | File present, no secrets |
+| 11.6 | Create `.dockerignore` — excludes `.venv/`, `__pycache__/`, `db.sqlite3`, `.git/` | `.dockerignore` | Lean build context |
+| 11.7 | Update `.github/workflows/docker-build.yml` — real build + GHA layer cache + smoke test | `.github/workflows/docker-build.yml` | CI green |
+
+**Settings hierarchy:**
+
+| Settings file | Use case | Oracle | DEMO_MODE |
+|---|---|---|---|
+| `settings.py` | Base (not used directly) | hardcoded | off |
+| `settings_dev.py` | Dev — `DATABASES={}` | off | off |
+| `settings_local.py` | Local UI: SQLite file db | off | on |
+| `settings_test.py` | CI integration: SQLite in-memory | off | off |
+| `settings_prod.py` | Production/Docker | env vars | auto |
+
+**Production Quick Start:**
+
+```bash
+cp .env.example .env          # fill DJANGO_SECRET_KEY at minimum
+docker compose up --build     # http://localhost:8000
+docker compose exec web python manage.py seed_demo  # optional demo data
+```
+
+---
+
 ## CI Quality Gates (active on every PR)
 
 | Job | Tool | What it enforces |
@@ -197,8 +267,24 @@ python manage.py tailwind install
 | `sql-lint` | sqlfluff 3+ | SQL hygiene in `databaseProject/` — exits non-zero on violations |
 | `template-lint` | djlint 1.36+ | Named endblocks, no collapsed `{% block %}` tags (T003) |
 | `tailwind-build` | Node 20 + npm | Compiled `theme/static/css/dist/styles.css` > 1 KB |
+| `docker-build` | Docker + GHA cache | Multi-stage image builds + `manage.py check --deploy` smoke test |
 
 Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
+
+---
+
+## Phase 12+ — Future Roadmap
+
+| Phase | Name | Description | Priority |
+|---|---|---|---|
+| 12 | Oracle Reconnect | Wire live Oracle catalog once DB is recreated — update `settings_prod.py` env vars, test `OracleRmanRepository` in Thin mode | High |
+| 13 | Nginx + TLS | Add Nginx reverse proxy container to `docker-compose.yml` — TLS termination via Let's Encrypt / self-signed | High |
+| 14 | Alerting & SLA Monitor | Use case: `CheckBackupSlaUseCase` — flags databases that missed their policy window; sends email / webhook | High |
+| 15 | Pagination + Filtering | Add server-side pagination to Reports and CRUD lists using `django-tables2` `RequestConfig` | Medium |
+| 16 | User Roles & Permissions | Extend `RelbackUser` with role (admin / viewer / operator) — guard views with role checks | Medium |
+| 17 | API Layer (DRF) | REST endpoints for backup status — expose `AuditBackupUseCase` results as JSON for external dashboards / Grafana | Medium |
+| 18 | Real-time Updates | WebSocket via Django Channels — live job status push to Reports table without page reload | Low |
+| 19 | Multi-tenant Support | Scope all Oracle catalog queries by `client_id` — support multiple RMAN catalogs per client | Low |
 
 ---
 
@@ -211,7 +297,7 @@ Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
 | #7 | #6 | chore | Remove EOL Angular.js + Materialize CSS |
 | #9 | #8 | fix | Integration tests after auth gates |
 | #11 | #10 | feat | Login / logout / register views wired |
-| #13 | #12 | feat | Tailwind CSS + DaisyUI Phase 1 — infrastructure |
+| #13 | #12 | feat | Phase 1 — Tailwind CSS + DaisyUI infrastructure |
 | #15 | #14 | feat | Phase 1 hardening — CSS guard, WCAG tokens, CI Tailwind build gate |
 | #17 | #16 | feat | Phase 2 — DaisyUI status badges + theme switcher |
 | #19 | #18 | chore | Commit package-lock.json + formatter normalisation |
@@ -221,51 +307,13 @@ Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
 | #27 | #26 | feat | Phase 4.3 — CRUD list views with DaisyUI `table` |
 | #29 | #28 | feat | Phase 4.4 — CRUD forms with DaisyUI `form-control` |
 | #31 | #30 | feat | Phase 5 — remaining templates + creators page |
-| #34 | #33 | feat | Live Oracle RMAN Catalog gateway + graceful fallback |
-| #36 | #35 | feat | Reports UI — oracle-available banner + running_jobs |
-| #38 | #37 | feat | Report log detail view (RC_RMAN_OUTPUT) |
+| #34 | #33 | feat | Phase 6 — Live Oracle RMAN Catalog gateway + graceful fallback |
+| #36 | #35 | feat | Phase 7 — Reports UI: oracle-available banner + running_jobs |
+| #38 | #37 | feat | Phase 8 — Report log detail view (RC_RMAN_OUTPUT) |
 | #40 | #39 | fix | Template formatter regression hotfix |
-| #42 | #41 | ci | sqlfluff hardening — remove `|| true` |
-| #44 | #43 | ci | djlint template-lint gate + named endblocks |
-
-
----
-
-## CI Quality Gates (active on every PR)
-
-| Job | Tool | What it enforces |
-|---|---|---|
-| `check-and-test` | Django + pytest | System check, 46 domain tests, 37 integration tests |
-| `sql-lint` | sqlfluff 3+ | SQL hygiene in `databaseProject/` — exits non-zero on violations |
-| `template-lint` | djlint 1.36+ | Named endblocks, no collapsed `{% block %}` tags (T003) |
-| `tailwind-build` | Node 20 + npm | Compiled `theme/static/css/dist/styles.css` > 1 KB |
-
-Config files: `.sqlfluff`, `.sqlfluffignore`, `.djlintrc`, `.prettierignore`
-
----
-
-## Completed Delivery History
-
-| PR | Issue | Type | Description |
-|---|---|---|---|
-| #2 | #1 | refactor | Initial Clean Architecture — CRUD use cases, entities, repositories |
-| #5 | #4 | feat | LoginRequiredMixin on all CRUD views |
-| #7 | #6 | chore | Remove EOL Angular.js + Materialize CSS |
-| #9 | #8 | fix | Integration tests after auth gates |
-| #11 | #10 | feat | Login / logout / register views wired |
-| #13 | #12 | feat | Tailwind CSS + DaisyUI Phase 1 — infrastructure |
-| #15 | #14 | feat | Phase 1 hardening — CSS guard, WCAG tokens, CI Tailwind build gate |
-| #17 | #16 | feat | Phase 2 — DaisyUI status badges + theme switcher |
-| #19 | #18 | chore | Commit package-lock.json + formatter normalisation |
-| #21 | #20 | feat | Phase 3 — DaisyUI drawer layout + auth templates |
-| #23 | #22 | feat | Phase 4.1 — Dashboard stats with DaisyUI `stats` |
-| #25 | #24 | feat | Phase 4.2 — Reports table + badge for backup status |
-| #27 | #26 | feat | Phase 4.3 — CRUD list views with DaisyUI table |
-| #29 | #28 | feat | Phase 4.4 — CRUD forms with DaisyUI form-control |
-| #31 | #30 | feat | Phase 5 — remaining templates + creators page |
-| #34 | #33 | feat | Live Oracle RMAN Catalog gateway + graceful fallback |
-| #36 | #35 | feat | Reports UI — oracle-available banner + running_jobs |
-| #38 | #37 | feat | Report log detail view (RC_RMAN_OUTPUT) |
-| #40 | #39 | fix | Template formatter regression hotfix |
-| #42 | #41 | ci | sqlfluff hardening — remove `|| true` |
-| #44 | #43 | ci | djlint template-lint gate + named endblocks |
+| #42 | #41 | ci | Phase 9a — sqlfluff hardening, remove `\|\| true` |
+| #44 | #43 | ci | Phase 9b — djlint template-lint gate + named endblocks |
+| #46 | #45 | feat | Phase 10 — Demo Mode: seed_demo, DemoRmanRepository, settings_local |
+| — | — | fix | Hotfix: stale SQLite wipe + re-migrate after model field additions |
+| #48 | #47 | feat | Dark theme palette — Indigo/Cyan replaces Oracle Red |
+| #50 | #49 | feat | Phase 11 — Dockerfile, Gunicorn, WhiteNoise, settings_prod, docker-compose |


### PR DESCRIPTION
## Summary
Full documentation refresh reflecting the current project state.

### ROADMAP_TAILWIND_DAISYUI.md
- Phase 2 dark-theme code block: updated to actual current Indigo/Cyan palette
- Added Phase 10 and Phase 11 detailed spec tables
- Added Phase 12+ future roadmap (Oracle Reconnect, Nginx/TLS, Alerting/SLA, Pagination, User Roles, DRF API, WebSockets, Multi-tenant)
- Delivery history completed: added PRs #46, hotfix, #48, #50
- Removed duplicated CI Quality Gates + Delivery History sections
- Added `docker-build` to CI gates table

### ARCHITECTURE.md
- DaisyUI Token table: now covers both `relback_light` and `relback_dark` with correct current hex values + WCAG AA notes
- Section 7 Configuration Files: added `settings_local.py`, `settings_prod.py`, `.env.example`, `.dockerignore`
- New Section 9: Production Deployment — Gunicorn, WhiteNoise, Docker multi-stage, env vars, Quick Start
- Section 10 (was 9): Project Structure — updated tree with new files

Closes #51