### PR TITLE
[Phase 13] Nginx + TLS (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,10 @@ DB_PORT=
 ORACLE_CATALOG_USER=
 ORACLE_CATALOG_PASSWORD=
 ORACLE_CATALOG_DSN=
+
+# ---------------------------------------------------------------------------
+# Nginx TLS (optional — for production with Let's Encrypt / certbot)
+# Leave unset: Nginx generates a self-signed cert for dev (HTTPS on 443).
+# Set to mount real certs in docker-compose: e.g. ./certs:/etc/nginx/certs:ro
+# ---------------------------------------------------------------------------
+# NGINX_CERTS_PATH=./certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,14 @@ version: "3.9"
 #    1. cp .env.example .env  && edit DJANGO_SECRET_KEY
 #    2. docker compose up --build
 #    3. docker compose exec web python manage.py seed_demo
-#    4. Open http://localhost:8000  |  login: admin / demo1234
+#    4. Open http://localhost:80 (via Nginx) or https://localhost:443 (self-signed)
+#       Direct Gunicorn: http://localhost:8000  |  login: admin / demo1234
 #
 #  Oracle production mode:
 #    Set DB_ENGINE, DB_NAME, DB_USER … and ORACLE_CATALOG_* in .env
+#
+#  TLS: Nginx generates a self-signed cert on first run (dev). For production,
+#  mount Let's Encrypt certs: add volume ./certs:/etc/nginx/certs:ro to nginx.
 # ---------------------------------------------------------------------------
 
 services:
@@ -18,14 +22,13 @@ services:
     build: .
     image: relback:latest
     restart: unless-stopped
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     env_file:
       - .env
     environment:
       DJANGO_SETTINGS_MODULE: projectRelback.settings_prod
     volumes:
-      # Persist SQLite database (ignored in Oracle mode)
       - relback_db:/app/db.sqlite3
     healthcheck:
       test: ["CMD", "python", "-c",
@@ -35,5 +38,25 @@ services:
       retries: 3
       start_period: 15s
 
+  nginx:
+    build: ./nginx
+    image: relback-nginx:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      web:
+        condition: service_healthy
+    volumes:
+      - nginx_certs:/etc/nginx/certs
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
 volumes:
   relback_db:
+  nginx_certs:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -338,10 +338,20 @@ Stage 2 (runtime)       python:3.13-slim
 
 ```bash
 cp .env.example .env        # fill DJANGO_SECRET_KEY at minimum
-docker compose up --build   # http://localhost:8000
+docker compose up --build   # http://localhost:80 (Nginx) or https://localhost:443 (self-signed)
 docker compose exec web python manage.py seed_demo  # optional demo data
 # Login: admin / demo1234
 ```
+
+### Nginx + TLS (reverse proxy)
+
+| Component | Role |
+| --------- | ----- |
+| **Nginx** | Reverse proxy in front of Gunicorn; listens on 80 (HTTP) and 443 (HTTPS). |
+| **Dev** | On first run, `nginx/entrypoint.sh` generates a self-signed certificate so HTTPS works without setup. |
+| **Prod** | Mount Let's Encrypt (certbot) certs: add to `docker-compose` for service `nginx`: `volumes: - ./certs:/etc/nginx/certs:ro` with `fullchain.pem` and `privkey.pem` in `./certs`. |
+
+**Files:** `nginx/nginx.conf`, `nginx/entrypoint.sh`, `nginx/Dockerfile`. Compose service `nginx` depends on `web` (healthcheck). Optional env in `.env.example`: `NGINX_CERTS_PATH` to document where prod certs live.
 
 ---
 
@@ -379,8 +389,9 @@ relback/
 │   ├── ARCHITECTURE.md          ← This document
 │   ├── ROADMAP_TAILWIND_DAISYUI.md
 │   └── UX_UI_analysis.md
+├── nginx/                       ← Nginx reverse proxy (Phase 13): nginx.conf, entrypoint.sh, Dockerfile
 ├── Dockerfile                   ← Multi-stage (Node 20 CSS + Python 3.13 Gunicorn)
-├── docker-compose.yml           ← One-command production preview
+├── docker-compose.yml           ← Web + Nginx; TLS self-signed (dev) or mount certs (prod)
 ├── .env.example                 ← Env var template (commit safe — no real values)
 ├── .dockerignore
 ├── .sqlfluff / .djlintrc        ← Lint configs

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,8 @@
+# Nginx reverse proxy for Relback (Gunicorn)
+# Uses entrypoint to generate self-signed cert for dev when no certs are mounted.
+FROM nginx:alpine
+RUN apk add --no-cache openssl
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Generate self-signed cert for dev if certs are not mounted (e.g. from certbot).
+set -e
+CERT_DIR="${CERT_DIR:-/etc/nginx/certs}"
+mkdir -p "$CERT_DIR"
+if [ ! -f "$CERT_DIR/privkey.pem" ]; then
+  echo "No TLS key found; generating self-signed certificate for development."
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout "$CERT_DIR/privkey.pem" \
+    -out "$CERT_DIR/fullchain.pem" \
+    -subj "/CN=localhost/O=Relback Dev"
+fi
+exec nginx -g "daemon off;"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,46 @@
+# Relback — Nginx reverse proxy for Gunicorn
+# HTTP on 80; HTTPS on 443 (self-signed in dev, or mount Let's Encrypt/certbot certs in prod).
+
+upstream relback_web {
+    server web:8000;
+}
+
+server {
+    listen 80;
+    server_name _;
+    client_max_body_size 10M;
+
+    location / {
+        proxy_pass http://relback_web;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    client_max_body_size 10M;
+
+    location / {
+        proxy_pass http://relback_web;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}


### PR DESCRIPTION
Closes #55

## Description
Phase 13 — Nginx reverse proxy in docker-compose with TLS (self-signed for dev, optional certbot mount for prod).

## Changes
- `nginx/`: Dockerfile, nginx.conf, entrypoint.sh (generates self-signed cert when no certs mounted)
- `docker-compose.yml`: added `nginx` service (ports 80, 443), `web` no longer exposes 8000 to host
- `.env.example`: optional NGINX_CERTS_PATH
- `docs/ARCHITECTURE.md`: Nginx + TLS section and project structure

## Verification
- `docker compose config` valid (requires .env present)
- `python manage.py check` passed

Made with [Cursor](https://cursor.com)