### PR TITLE
[Phase 15] Pagination + Filtering (#59)

### DIFF
--- a/coreRelback/tables.py
+++ b/coreRelback/tables.py
@@ -1,0 +1,107 @@
+"""
+django-tables2 Table classes for server-side pagination and sorting.
+
+Used with RequestConfig in views to enable ?page= and ?sort= query params.
+"""
+import django_tables2 as tables
+
+from .models import Client, Host, Database, BackupPolicy
+
+
+class ClientTable(tables.Table):
+    """Clients list with pagination."""
+
+    name = tables.Column(verbose_name="Client Name", order_by="name")
+    description = tables.Column(verbose_name="Description")
+    created_at = tables.DateTimeColumn(format="M d, Y", verbose_name="Created")
+    actions = tables.TemplateColumn(
+        verbose_name="Actions",
+        template_name="coreRelback/table_actions_client.html",
+        orderable=False,
+    )
+
+    class Meta:
+        model = Client
+        attrs = {"class": "table table-xs table-zebra w-full"}
+        fields = ("name", "description", "created_at", "actions")
+        per_page = 25
+
+
+class HostTable(tables.Table):
+    """Hosts list with pagination."""
+
+    hostname = tables.Column(verbose_name="Hostname", order_by="hostname")
+    ip = tables.Column(verbose_name="IP")
+    client = tables.Column(verbose_name="Client", accessor="client.name")
+    created_at = tables.DateTimeColumn(format="M d, Y", verbose_name="Created")
+    actions = tables.TemplateColumn(
+        verbose_name="Actions",
+        template_name="coreRelback/table_actions_host.html",
+        orderable=False,
+    )
+
+    class Meta:
+        model = Host
+        attrs = {"class": "table table-xs table-zebra w-full"}
+        fields = ("hostname", "ip", "client", "created_at", "actions")
+        per_page = 25
+
+
+class DatabaseTable(tables.Table):
+    """Databases list with pagination."""
+
+    db_name = tables.Column(verbose_name="Database", order_by="db_name")
+    dbid = tables.Column(verbose_name="DBID")
+    host = tables.Column(verbose_name="Host", accessor="host.hostname")
+    client = tables.Column(verbose_name="Client", accessor="client.name")
+    created_at = tables.DateTimeColumn(format="M d, Y", verbose_name="Created")
+    actions = tables.TemplateColumn(
+        verbose_name="Actions",
+        template_name="coreRelback/table_actions_database.html",
+        orderable=False,
+    )
+
+    class Meta:
+        model = Database
+        attrs = {"class": "table table-xs table-zebra w-full"}
+        fields = ("db_name", "dbid", "host", "client", "created_at", "actions")
+        per_page = 25
+
+
+class BackupPolicyTable(tables.Table):
+    """Backup policies list with pagination."""
+
+    policy_name = tables.Column(verbose_name="Policy", order_by="policy_name")
+    backup_type = tables.Column(verbose_name="Type")
+    database = tables.Column(verbose_name="Database", accessor="database.db_name")
+    host = tables.Column(verbose_name="Host", accessor="host.hostname")
+    created_at = tables.DateTimeColumn(format="M d, Y", verbose_name="Created")
+    actions = tables.TemplateColumn(
+        verbose_name="Actions",
+        template_name="coreRelback/table_actions_policy.html",
+        orderable=False,
+    )
+
+    class Meta:
+        model = BackupPolicy
+        attrs = {"class": "table table-xs table-zebra w-full"}
+        fields = ("policy_name", "backup_type", "database", "host", "created_at", "actions")
+        per_page = 25
+
+
+class ReportJobTable(tables.Table):
+    """Reports page: backup jobs (list of dicts). No model; data from view."""
+
+    policy_name = tables.Column(verbose_name="Policy")
+    hostname = tables.Column(verbose_name="Host")
+    db_name = tables.Column(verbose_name="Database")
+    backup_type = tables.Column(verbose_name="Type")
+    start_time = tables.DateTimeColumn(format="M d, Y H:i", verbose_name="Start")
+    end_time = tables.DateTimeColumn(format="M d, Y H:i", verbose_name="End")
+    status = tables.Column(verbose_name="Status")
+    time_taken_display = tables.Column(verbose_name="Duration")
+    output_bytes_display = tables.Column(verbose_name="Size")
+
+    class Meta:
+        attrs = {"class": "table table-xs table-zebra w-full"}
+        per_page = 25

--- a/coreRelback/templates/clients.html
+++ b/coreRelback/templates/clients.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load django_tables2 %}
 
 {% block title %}Clients - RelBack{% endblock title %}
 
@@ -31,14 +32,14 @@
                 <i class="material-icons-round" style="font-size: 2.5rem;">business</i>
             </div>
             <div class="stat-title">Total Clients</div>
-            <div class="stat-value stats-title">{{ clients.count }}</div>
+            <div class="stat-value stats-title">{{ clients_count|default:0 }}</div>
         </div>
         <div class="stat">
             <div class="stat-figure text-success">
                 <i class="material-icons-round" style="font-size: 2.5rem;">verified</i>
             </div>
             <div class="stat-title">Active Clients</div>
-            <div class="stat-value text-success stats-title">{{ clients|length }}</div>
+            <div class="stat-value text-success stats-title">{{ clients_count|default:0 }}</div>
         </div>
     </div>
 
@@ -58,74 +59,12 @@
         </div>
     </div>
 
-    <!-- Clients Table -->
+    <!-- Clients Table (django-tables2 pagination) -->
     <div>
         <div class="md-card md-card-decorated">
-            {% if clients %}
+            {% if table.page.object_list %}
                 <div class="overflow-x-auto">
-                    <table class="table table-xs table-zebra w-full">
-                        <thead>
-                            <tr>
-                                <th class="oracle-info-gradient">
-                                    <div class="table-header-content">
-                                        <i class="material-icons table-header-icon">business</i>
-                                        <span class="table-header-text">Client Name</span>
-                                    </div>
-                                </th>
-                                <th class="oracle-info-gradient">
-                                    <i class="material-icons table-header-icon">description</i>
-                                    <span class="table-header-text">Description</span>
-                                </th>
-                                <th class="oracle-info-gradient">
-                                    <i class="material-icons table-header-icon">schedule</i>
-                                    <span class="table-header-text">Created</span>
-                                </th>
-                                <th class="oracle-info-gradient">
-                                    <i class="material-icons table-header-icon">settings</i>
-                                    <span class="table-header-text">Actions</span>
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for client in clients %}
-                            <tr>
-                                <td>
-                                    <div class="table-cell-content">
-                                        <div class="table-cell-icon">
-                                            <i class="material-icons-round">business</i>
-                                        </div>
-                                        <div>
-                                            <h5 class="table-cell-title">{{ client.name|default:"Unnamed Client" }}</h5>
-                                            <small class="table-cell-subtitle">ID: {{ client.id_client }}</small>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td>
-                                    <span class="table-cell-text">{{ client.description|default:"No description" }}</span>
-                                </td>
-                                <td>
-                                    <span class="table-cell-text">{{ client.created_at|date:"M d, Y" }}</span>
-                                </td>
-                                <td>
-                                    <div class="btn-actions-group">
-                                        <button type="button" 
-                                                class="btn-action btn-edit" 
-                                                title="Edit Client"
-                                                onclick="openEditModal('{{ client.id_client }}', '{{ client.name|escapejs }}', '{{ client.description|default:""|escapejs }}')">
-                                            <i class="material-icons-round">edit</i>
-                                        </button>
-                                        <button type="button" 
-                                                class="btn-action btn-delete" 
-                                                title="Delete Client"
-                                                onclick="openDeleteModal('{{ client.id_client }}', '{{ client.name|escapejs }}', '{{ client.description|default:"No description"|escapejs }}', '{{ client.created_at|date:"F d, Y G:i" }}')">
-                                            <i class="material-icons-round">delete</i>
-                                        </button>
-                                    </div>
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                    {% render_table table %}
                 </div>
             {% else %}
                 <!-- Empty State -->

--- a/coreRelback/templates/coreRelback/table_actions_client.html
+++ b/coreRelback/templates/coreRelback/table_actions_client.html
@@ -1,0 +1,10 @@
+<div class="btn-actions-group">
+    <button type="button" class="btn-action btn-edit" title="Edit Client"
+            onclick="openEditModal('{{ record.id_client }}', '{{ record.name|default:'Unnamed'|escapejs }}', '{{ record.description|default:'-'|escapejs }}')">
+        <i class="material-icons-round">edit</i>
+    </button>
+    <button type="button" class="btn-action btn-delete" title="Delete Client"
+            onclick="openDeleteModal('{{ record.id_client }}', '{{ record.name|default:''|escapejs }}', '{{ record.description|default:'No description'|escapejs }}', '{{ record.created_at|date:'F d, Y G:i' }}')">
+        <i class="material-icons-round">delete</i>
+    </button>
+</div>

--- a/coreRelback/templates/coreRelback/table_actions_database.html
+++ b/coreRelback/templates/coreRelback/table_actions_database.html
@@ -1,0 +1,2 @@
+<a href="{% url 'coreRelback:database-update' record.id_database %}" class="btn-action btn-edit" title="Edit"><i class="material-icons-round">edit</i></a>
+<a href="{% url 'coreRelback:database-delete' record.id_database %}" class="btn-action btn-delete" title="Delete"><i class="material-icons-round">delete</i></a>

--- a/coreRelback/templates/coreRelback/table_actions_host.html
+++ b/coreRelback/templates/coreRelback/table_actions_host.html
@@ -1,0 +1,2 @@
+<a href="{% url 'coreRelback:host-update' record.id_host %}" class="btn-action btn-edit" title="Edit"><i class="material-icons-round">edit</i></a>
+<a href="{% url 'coreRelback:host-delete' record.id_host %}" class="btn-action btn-delete" title="Delete"><i class="material-icons-round">delete</i></a>

--- a/coreRelback/templates/coreRelback/table_actions_policy.html
+++ b/coreRelback/templates/coreRelback/table_actions_policy.html
@@ -1,0 +1,2 @@
+<a href="{% url 'coreRelback:policy-update' record.id_policy %}" class="btn-action btn-edit" title="Edit"><i class="material-icons-round">edit</i></a>
+<a href="{% url 'coreRelback:policy-delete' record.id_policy %}" class="btn-action btn-delete" title="Delete"><i class="material-icons-round">delete</i></a>

--- a/coreRelback/views.py
+++ b/coreRelback/views.py
@@ -5,7 +5,10 @@ from django.views.generic import ListView, CreateView, UpdateView, DeleteView, D
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
+from django_tables2 import RequestConfig
+from django.db.models import Q
 from .models import Client, Host, Database, BackupPolicy, RelbackUser, Schedule
+from .tables import ClientTable, HostTable, DatabaseTable, BackupPolicyTable
 from django import forms
 
 # --- Clean Architecture: use-case factories ---
@@ -144,6 +147,21 @@ class ClientListView(LoginRequiredMixin, ListView):
     template_name = "clients.html"
     context_object_name = "clients"
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        search = (self.request.GET.get("search") or "").strip()
+        if search:
+            qs = qs.filter(Q(name__icontains=search) | Q(description__icontains=search))
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        table = ClientTable(self.get_queryset())
+        RequestConfig(self.request, paginate={"per_page": 25}).configure(table)
+        context["table"] = table
+        context["clients_count"] = self.get_queryset().count()
+        return context
+
 
 class ClientCreateView(LoginRequiredMixin, CreateView):
     model = Client
@@ -205,19 +223,24 @@ class HostListView(LoginRequiredMixin, ListView):
     template_name = "hosts.html"
     context_object_name = "hosts"
 
+    def get_queryset(self):
+        qs = super().get_queryset().select_related("client")
+        search = (self.request.GET.get("search") or "").strip()
+        if search:
+            qs = qs.filter(hostname__icontains=search) | qs.filter(ip__icontains=search)
+        return qs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        hosts = self.get_queryset().select_related('client')
-
-        # Estatísticas para os cards (removendo filtro por status que não existe)
-        context['total_hosts'] = hosts.count()
-        # Assumindo que todos hosts listados estão ativos
-        context['active_hosts'] = hosts.count()
-        context['total_clients'] = Client.objects.count()
-        context['total_databases'] = Database.objects.filter(
-            host__in=hosts).count()
-        context['clients'] = Client.objects.all()  # Para o filtro
-
+        hosts = self.get_queryset()
+        table = HostTable(hosts)
+        RequestConfig(self.request, paginate={"per_page": 25}).configure(table)
+        context["table"] = table
+        context["total_hosts"] = hosts.count()
+        context["active_hosts"] = hosts.count()
+        context["total_clients"] = Client.objects.count()
+        context["total_databases"] = Database.objects.filter(host__in=hosts).count()
+        context["clients"] = Client.objects.all()
         return context
 
 
@@ -284,18 +307,23 @@ class DatabaseListView(LoginRequiredMixin, ListView):
     template_name = "databases.html"
     context_object_name = "databases"
 
+    def get_queryset(self):
+        qs = super().get_queryset().select_related("client", "host")
+        search = (self.request.GET.get("search") or "").strip()
+        if search:
+            qs = qs.filter(Q(db_name__icontains=search) | Q(description__icontains=search))
+        return qs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        databases = self.get_queryset().select_related('client', 'host')
-
-        # Estatísticas para os cards (removendo filtro por active que não existe)
-        context['total_databases'] = databases.count()
-        # Assumindo que todos databases listados estão ativos
-        context['active_databases'] = databases.count()
-        context['total_hosts'] = Host.objects.count()
-        context['total_policies'] = BackupPolicy.objects.filter(
-            database__in=databases).count()
-
+        databases = self.get_queryset()
+        table = DatabaseTable(databases)
+        RequestConfig(self.request, paginate={"per_page": 25}).configure(table)
+        context["table"] = table
+        context["total_databases"] = databases.count()
+        context["active_databases"] = databases.count()
+        context["total_hosts"] = Host.objects.count()
+        context["total_policies"] = BackupPolicy.objects.filter(database__in=databases).count()
         return context
 
 
@@ -374,20 +402,24 @@ class BackupPolicyListView(LoginRequiredMixin, ListView):
     template_name = "policies.html"
     context_object_name = "policies"
 
+    def get_queryset(self):
+        qs = super().get_queryset().select_related("client", "database", "host")
+        search = (self.request.GET.get("search") or "").strip()
+        if search:
+            qs = qs.filter(Q(policy_name__icontains=search) | Q(backup_type__icontains=search))
+        return qs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        policies = self.get_queryset().select_related('client', 'database', 'host')
-
-        # Estatísticas para os cards
-        context['total_policies'] = policies.count()
-        context['active_policies'] = policies.filter(
-            status__iexact='ACTIVE').count()
-        context['inactive_policies'] = policies.filter(
-            status__iexact='INACTIVE').count()
-        context['scheduled_policies'] = policies.filter(
-            status__iexact='ACTIVE').count() // 2
-        context['clients'] = Client.objects.all()  # Para o filtro
-
+        policies = self.get_queryset()
+        table = BackupPolicyTable(policies)
+        RequestConfig(self.request, paginate={"per_page": 25}).configure(table)
+        context["table"] = table
+        context["total_policies"] = policies.count()
+        context["active_policies"] = policies.filter(status__iexact="ACTIVE").count()
+        context["inactive_policies"] = policies.filter(status__iexact="INACTIVE").count()
+        context["scheduled_policies"] = policies.filter(status__iexact="ACTIVE").count() // 2
+        context["clients"] = Client.objects.all()
         return context
 
 


### PR DESCRIPTION
Closes #59

## Description
Phase 15 — Server-side pagination and optional filters with django-tables2.

## Changes
- **15.1** `coreRelback/tables.py`: ClientTable, HostTable, DatabaseTable, BackupPolicyTable, ReportJobTable (ready for Reports).
- **15.2** Client list: `RequestConfig` + `{% render_table table %}` in `clients.html`. Host/Database/Policy list views: table in context (templates can switch to `render_table` when desired).
- **15.3** Query params: `?search=` filter on Client (name/description), Host (hostname/ip), Database (db_name/description), Policy (policy_name/backup_type).

## Verification
- `python manage.py check` passed.
- Clients page: 25 per page, pagination links, search by name/description.

Made with [Cursor](https://cursor.com)