### PR TITLE
feat(ui): Row click opens view modal with Edit button on all list screens

### DIFF
--- a/coreRelback/templates/clients.html
+++ b/coreRelback/templates/clients.html
@@ -90,7 +90,11 @@
                     </thead>
                     <tbody>
                         {% for client in clients %}
-                        <tr class="client-row cursor-pointer">
+                        <tr class="client-row cursor-pointer"
+                            data-client-id="{{ client.id_client }}"
+                            data-client-name="{{ client.name|default:'Unnamed Client'|escapejs }}"
+                            data-client-description="{{ client.description|default:''|escapejs }}"
+                            data-client-created="{{ client.created_at|date:'Y-m-d H:i' }}">
                             <td>
                                 <div class="flex items-center gap-3">
                                     <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
@@ -108,7 +112,7 @@
                             <td>
                                 <span class="text-sm">{{ client.created_at|date:"M d, Y" }}</span>
                             </td>
-                            <td>
+                            <td class="client-row-actions" onclick="event.stopPropagation()">
                                 <div class="flex items-center gap-1">
                                     <button type="button"
                                             class="btn btn-ghost btn-xs"
@@ -141,6 +145,50 @@
             </div>
         {% endif %}
     </div>
+</div>
+
+<!-- View Client Modal (read-only) -->
+<div class="modal" id="viewClientModal">
+    <div class="modal-box max-w-lg">
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-bold flex items-center gap-2">
+                <i class="material-icons-round text-primary">visibility</i>
+                Client Details
+            </h3>
+            <button type="button" class="btn btn-ghost btn-sm btn-circle" onclick="closeViewModal()">
+                <i class="material-icons-round">close</i>
+            </button>
+        </div>
+        <div class="bg-base-200 rounded-lg p-4 space-y-3 mb-4">
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Client Name</span>
+                <span class="font-medium" id="view-client-name">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Client ID</span>
+                <code class="font-mono text-sm" id="view-client-id">—</code>
+            </div>
+            <div class="flex justify-between text-sm items-start">
+                <span class="text-base-content/60">Description</span>
+                <span class="text-right max-w-[60%]" id="view-client-description">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Created</span>
+                <span id="view-client-created">—</span>
+            </div>
+        </div>
+        <div class="modal-action">
+            <button type="button" class="btn btn-ghost" onclick="closeViewModal()">
+                <i class="material-icons-round text-lg">close</i>
+                Close
+            </button>
+            <button type="button" class="btn btn-primary" id="viewClientEditBtn">
+                <i class="material-icons-round text-lg">edit</i>
+                Edit
+            </button>
+        </div>
+    </div>
+    <div class="modal-backdrop" onclick="closeViewModal()"></div>
 </div>
 
 <!-- Delete Confirmation Modal -->
@@ -606,6 +654,25 @@ document.getElementById('cleanBtn').addEventListener('click', function() {
     searchInput.focus();
 });
 
+function openViewModal(row) {
+    const d = row.dataset;
+    document.getElementById('view-client-name').textContent = d.clientName || '—';
+    document.getElementById('view-client-id').textContent = d.clientId || '—';
+    document.getElementById('view-client-description').textContent = d.clientDescription || '—';
+    document.getElementById('view-client-created').textContent = d.clientCreated || '—';
+    const viewModal = document.getElementById('viewClientModal');
+    viewModal.dataset.clientId = d.clientId || '';
+    viewModal.dataset.clientName = d.clientName || '';
+    viewModal.dataset.clientDescription = d.clientDescription || '';
+    viewModal.classList.add('modal-open');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeViewModal() {
+    document.getElementById('viewClientModal').classList.remove('modal-open');
+    document.body.style.overflow = '';
+}
+
 function openDeleteModal(clientId, clientName, clientDescription, clientCreated) {
     document.getElementById('modal-client-name').textContent = clientName;
     document.getElementById('modal-client-description').textContent = clientDescription;
@@ -729,7 +796,40 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    const tbody = document.querySelector('.overflow-x-auto tbody');
+    if (tbody) {
+        tbody.addEventListener('click', function(e) {
+            const row = e.target.closest('tr.client-row');
+            if (!row || e.target.closest('.client-row-actions')) return;
+            openViewModal(row);
+        });
+    }
+
+    const viewClientEditBtn = document.getElementById('viewClientEditBtn');
+    if (viewClientEditBtn) {
+        viewClientEditBtn.addEventListener('click', function() {
+            const d = document.getElementById('viewClientModal').dataset;
+            closeViewModal();
+            openEditModal(d.clientId || '', d.clientName || '', d.clientDescription || '');
+        });
+    }
+
     searchInput.focus();
+});
+
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        const viewModal = document.getElementById('viewClientModal');
+        const deleteModal = document.getElementById('deleteClientModal');
+        const editModal = document.getElementById('editClientModal');
+        if (viewModal && viewModal.classList.contains('modal-open')) {
+            closeViewModal();
+        } else if (deleteModal && deleteModal.classList.contains('modal-open')) {
+            closeDeleteModal();
+        } else if (editModal && editModal.classList.contains('modal-open')) {
+            closeEditModal();
+        }
+    }
 });
 </script>
 {% endblock content %}

--- a/coreRelback/templates/databases.html
+++ b/coreRelback/templates/databases.html
@@ -123,10 +123,17 @@
                     <tbody>
                     {% for database in databases %}
                     <tr class="database-row cursor-pointer"
-                        data-host="{{ database.host.hostname|default:'Unknown' }}"
+                        data-database-id="{{ database.id_database }}"
+                        data-db-name="{{ database.db_name|default:'Unnamed Database'|escapejs }}"
+                        data-description="{{ database.description|default:''|escapejs }}"
+                        data-client-id="{{ database.client_id|default:'' }}"
+                        data-client-name="{{ database.client.name|default:'No Client'|escapejs }}"
+                        data-host-id="{{ database.host_id|default:'' }}"
+                        data-host="{{ database.host.hostname|default:'No Host'|escapejs }}"
+                        data-dbid="{{ database.dbid|default:'0' }}"
                         data-type="{{ database.db_type|default:'Unknown' }}"
                         data-status="{% if database.active %}active{% else %}inactive{% endif %}"
-                        data-backup="{% if database.last_backup_date %}{% with now_timestamp=now|date:'U'|add:'-604800' backup_timestamp=database.last_backup_date|date:'U' %}{% if backup_timestamp > now_timestamp %}recent{% else %}old{% endif %}{% endwith %}{% else %}none{% endif %}">
+                        data-backup="{% if database.last_backup_date %}{{ database.last_backup_date|date:'Y-m-d' }}{% else %}Never{% endif %}">
                         <td>
                             <div class="flex items-center gap-3">
                                 <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
@@ -203,26 +210,20 @@
                             </div>
                             {% endif %}
                         </td>
-                        <td>
+                        <td class="database-row-actions" onclick="event.stopPropagation()">
                             <div class="flex items-center gap-1">
-                                <a href="#"
-                                   class="btn btn-ghost btn-xs"
-                                   title="View Details"
-                                   onclick="openViewModal('{{ database.id_database }}', '{{ database.db_name|escapejs }}', '{{ database.description|default:''|escapejs }}', '{{ database.host.hostname|default:'No Host'|escapejs }}', '{{ database.db_type|default:'Unknown'|escapejs }}')">
-                                    <i class="material-icons-round text-sm">visibility</i>
-                                </a>
-                                <a href="#"
+                                <button type="button"
                                    class="btn btn-ghost btn-xs"
                                    title="Edit Database"
                                    onclick="openEditModal('{{ database.id_database }}', '{{ database.db_name|escapejs }}', '{{ database.description|default:''|escapejs }}', '{{ database.client_id }}', '{{ database.host_id }}', '{{ database.dbid }}')">
                                     <i class="material-icons-round text-sm">edit</i>
-                                </a>
-                                <a href="#"
+                                </button>
+                                <button type="button"
                                    class="btn btn-ghost btn-xs text-error"
                                    title="Delete Database"
                                    onclick="openDeleteModal('{{ database.id_database }}', '{{ database.db_name|escapejs }}', '{{ database.description|default:''|escapejs }}', '{{ database.host.hostname|default:'No Host'|escapejs }}')">
                                     <i class="material-icons-round text-sm">delete</i>
-                                </a>
+                                </button>
                             </div>
                         </td>
                     </tr>
@@ -268,39 +269,53 @@
             </div>
         </div>
 
-        <div class="space-y-3">
-            <h6 class="flex items-center gap-2 font-semibold text-sm">
-                <i class="material-icons-round text-sm">storage</i>
-                Basic Information
-            </h6>
-            <div class="bg-base-200 rounded-lg p-4 space-y-2">
-                <div class="flex justify-between text-sm">
-                    <strong>Database Name:</strong>
-                    <span id="view-database-name"></span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <strong>Description:</strong>
-                    <span id="view-database-description"></span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <strong>Database ID:</strong>
-                    <span id="view-database-id"></span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <strong>Host:</strong>
-                    <span id="view-database-host"></span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <strong>Type:</strong>
-                    <span id="view-database-type"></span>
-                </div>
+        <div class="bg-base-200 rounded-lg p-4 space-y-3">
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Database Name</span>
+                <code class="font-mono text-sm" id="view-database-name">—</code>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Database ID</span>
+                <span class="font-mono text-sm" id="view-database-id">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Client</span>
+                <span id="view-database-client">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Host</span>
+                <span class="font-mono text-sm" id="view-database-host">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Type</span>
+                <span id="view-database-type">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">DBID</span>
+                <span class="font-mono text-sm" id="view-database-dbid">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Status</span>
+                <span id="view-database-status">—</span>
+            </div>
+            <div class="flex justify-between text-sm">
+                <span class="text-base-content/60">Last Backup</span>
+                <span class="font-mono text-sm" id="view-database-backup">—</span>
+            </div>
+            <div class="flex justify-between text-sm items-start">
+                <span class="text-base-content/60">Description</span>
+                <span class="text-right max-w-[60%]" id="view-database-description">—</span>
             </div>
         </div>
 
-        <div class="modal-action">
+        <div class="modal-action mt-4">
             <button type="button" class="btn btn-ghost" onclick="closeViewModal()">
                 <i class="material-icons-round text-lg">close</i>
                 Close
+            </button>
+            <button type="button" class="btn btn-primary" id="viewDatabaseEditBtn">
+                <i class="material-icons-round text-lg">edit</i>
+                Edit
             </button>
         </div>
     </div>
@@ -712,14 +727,24 @@ document.getElementById('cleanBtn').addEventListener('click', function() {
     searchInput.focus();
 });
 
-function openViewModal(databaseId, databaseName, databaseDescription, databaseHost, databaseType) {
-    document.getElementById('view-database-name').textContent = databaseName;
-    document.getElementById('view-database-description').textContent = databaseDescription || 'No description';
-    document.getElementById('view-database-id').textContent = databaseId;
-    document.getElementById('view-database-host').textContent = databaseHost;
-    document.getElementById('view-database-type').textContent = databaseType;
-
+function openViewModal(row) {
+    const d = row.dataset;
+    document.getElementById('view-database-name').textContent = d.dbName || '—';
+    document.getElementById('view-database-id').textContent = d.databaseId || '—';
+    document.getElementById('view-database-client').textContent = d.clientName || '—';
+    document.getElementById('view-database-host').textContent = d.host || '—';
+    document.getElementById('view-database-type').textContent = d.type || '—';
+    document.getElementById('view-database-dbid').textContent = d.dbid || '—';
+    document.getElementById('view-database-status').textContent = d.status === 'active' ? 'Active' : 'Inactive';
+    document.getElementById('view-database-backup').textContent = d.backup || 'Never';
+    document.getElementById('view-database-description').textContent = d.description || '—';
     const modal = document.getElementById('viewDatabaseModal');
+    modal.dataset.databaseId = d.databaseId || '';
+    modal.dataset.dbName = d.dbName || '';
+    modal.dataset.description = d.description || '';
+    modal.dataset.clientId = d.clientId || '';
+    modal.dataset.hostId = d.hostId || '';
+    modal.dataset.dbid = d.dbid || '';
     modal.classList.add('modal-open');
     document.body.style.overflow = 'hidden';
 }
@@ -924,6 +949,24 @@ document.addEventListener('DOMContentLoaded', function() {
     const addButton = document.querySelector('[data-modal-target="#addDatabaseModal"]');
     if (addButton) {
         addButton.addEventListener('click', openAddModal);
+    }
+
+    const tbody = document.querySelector('.overflow-x-auto tbody');
+    if (tbody) {
+        tbody.addEventListener('click', function(e) {
+            const row = e.target.closest('tr.database-row');
+            if (!row || e.target.closest('.database-row-actions')) return;
+            openViewModal(row);
+        });
+    }
+
+    const viewDatabaseEditBtn = document.getElementById('viewDatabaseEditBtn');
+    if (viewDatabaseEditBtn) {
+        viewDatabaseEditBtn.addEventListener('click', function() {
+            const d = document.getElementById('viewDatabaseModal').dataset;
+            closeViewModal();
+            openEditModal(d.databaseId || '', d.dbName || '', d.description || '', d.clientId || '', d.hostId || '', d.dbid || '');
+        });
     }
 
     searchInput.focus();

--- a/coreRelback/templates/policies.html
+++ b/coreRelback/templates/policies.html
@@ -222,12 +222,7 @@
                                 {% endif %}
                             </td>
                             <td class="text-center">
-                                <div class="flex items-center justify-center gap-1">
-                                    <button type="button" class="btn btn-ghost btn-xs"
-                                            onclick="openViewModal('{{ policy.id_policy }}', '{{ policy.policy_name|escapejs }}', '{{ policy.description|default:'No description'|escapejs }}', '{{ policy.client.name|default:'No Client'|escapejs }}', '{{ policy.host.hostname|default:'No Host'|escapejs }}', '{{ policy.database.db_name|default:'No Database'|escapejs }}', '{{ policy.backup_type|default:'Unknown'|escapejs }}', '{% if policy.status == '1' %}Active{% else %}Inactive{% endif %}', '{{ policy.hour|default:'*' }}:{{ policy.minute|default:'00' }}', '{% if policy.day_week %}Weekly ({{ policy.day_week }}){% elif policy.day %}Monthly ({{ policy.day }}){% else %}Daily{% endif %}')"
-                                            title="View Details">
-                                        <i class="material-icons-round text-sm">visibility</i>
-                                    </button>
+                                <div class="flex items-center justify-center gap-1" onclick="event.stopPropagation()">
                                     <button type="button" class="btn btn-ghost btn-xs"
                                             onclick="openEditModal(this.closest('tr'))"
                                             title="Edit">
@@ -333,6 +328,10 @@
             <button type="button" class="btn btn-ghost" onclick="closeViewModal()">
                 <i class="material-icons-round text-lg mr-1">close</i>
                 Close
+            </button>
+            <button type="button" class="btn btn-primary" id="viewPolicyEditBtn">
+                <i class="material-icons-round text-lg">edit</i>
+                Edit
             </button>
         </div>
     </div>
@@ -829,19 +828,25 @@ document.getElementById('cleanBtn').addEventListener('click', function() {
     searchInput.focus();
 });
 
-function openViewModal(policyId, policyName, policyDescription, policyClient, policyHost, policyDatabase, policyType, policyStatus, policyTime, policyFrequency) {
-    document.getElementById('view-policy-id').textContent = policyId;
-    document.getElementById('view-policy-name').textContent = policyName;
-    document.getElementById('view-policy-description').textContent = policyDescription || 'No description';
-    document.getElementById('view-policy-client').textContent = policyClient;
-    document.getElementById('view-policy-host').textContent = policyHost;
-    document.getElementById('view-policy-database').textContent = policyDatabase;
-    document.getElementById('view-policy-type').textContent = policyType;
-    document.getElementById('view-policy-status').textContent = policyStatus;
-    document.getElementById('view-policy-time').textContent = policyTime;
-    document.getElementById('view-policy-frequency').textContent = policyFrequency;
-
+function openViewModal(row) {
+    const d = row.dataset;
+    document.getElementById('view-policy-id').textContent = '#' + (d.policyId || '—');
+    document.getElementById('view-policy-name').textContent = d.policyName || '—';
+    document.getElementById('view-policy-description').textContent = d.policyDescription || '—';
+    document.getElementById('view-policy-client').textContent = d.client || '—';
+    document.getElementById('view-policy-host').textContent = d.host || '—';
+    document.getElementById('view-policy-database').textContent = d.database || '—';
+    document.getElementById('view-policy-type').textContent = d.backupType || '—';
+    const st = d.status || '';
+    document.getElementById('view-policy-status').textContent = (st === '1' || st.toLowerCase() === 'active') ? 'Active' : 'Inactive';
+    document.getElementById('view-policy-time').textContent = (d.hour || '*') + ':' + (d.minute || '00');
+    const dw = d.dayWeek, dy = d.day;
+    document.getElementById('view-policy-frequency').textContent =
+        dw && dw !== '*' ? 'Weekly (day ' + dw + ')' :
+        dy && dy !== '*' ? 'Monthly (day ' + dy + ')' : 'Daily';
     const modal = document.getElementById('viewPolicyModal');
+    modal.dataset.rowRef = '';
+    modal._rowRef = row;
     modal.classList.add('modal-open');
     document.body.style.overflow = 'hidden';
 }
@@ -1072,6 +1077,27 @@ document.addEventListener('DOMContentLoaded', function() {
     const addButton = document.querySelector('[data-modal-target="#addPolicyModal"]');
     if (addButton) {
         addButton.addEventListener('click', openAddModal);
+    }
+
+    const tbody = document.querySelector('.overflow-x-auto tbody');
+    if (tbody) {
+        tbody.addEventListener('click', function(e) {
+            const row = e.target.closest('tr.policy-row');
+            if (!row) return;
+            const actions = e.target.closest('[onclick]');
+            if (actions) return;
+            openViewModal(row);
+        });
+    }
+
+    const viewPolicyEditBtn = document.getElementById('viewPolicyEditBtn');
+    if (viewPolicyEditBtn) {
+        viewPolicyEditBtn.addEventListener('click', function() {
+            const modal = document.getElementById('viewPolicyModal');
+            const row = modal._rowRef;
+            closeViewModal();
+            if (row) openEditModal(row);
+        });
     }
 
     searchInput.focus();


### PR DESCRIPTION
## Summary
- **Clients**: new view modal (read-only) with all fields; click any row → modal; Edit button opens edit modal; Escape closes.
- **Databases**: expanded `data-*` on rows; removed redundant View icon button; Edit button added to existing view modal; row click triggers view modal.
- **Policies**: removed redundant View icon button; Edit button added to existing view modal; row click triggers view modal from `data-*` already on rows.
- **All screens**: actions column (`onclick="event.stopPropagation()"`) prevents row click when using Edit/Delete buttons.

## Test plan
- [ ] Click any row in Clients, Databases, Policies → view modal opens
- [ ] Click Edit button inside view modal → view modal closes, edit modal opens pre-filled
- [ ] Click Edit/Delete buttons in Actions column → only that modal opens (no view modal)
- [ ] Press Escape → closes the frontmost modal

Made with [Cursor](https://cursor.com)