### PR TITLE
fix(ci): resolve CI, Docker Build and GitHub Pages failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Install npm dependencies first (cached layer if package.json unchanged)
 COPY theme/static_src/package*.json theme/static_src/
-RUN cd theme/static_src && npm ci --omit=dev --silent
+RUN cd theme/static_src && npm ci --silent
 
 # Copy config + source CSS
 COPY theme/static_src/tailwind.config.js theme/static_src/

--- a/coreRelback/templates/base.html
+++ b/coreRelback/templates/base.html
@@ -120,7 +120,7 @@
 
         {# ── Footer ──────────────────────────────────────────────────── #}
         <footer class="py-3 px-4 border-t border-base-300 text-center text-xs text-base-content/40">
-          &copy; 2025 RelBack — Backup Monitor
+          © 2025 RelBack — Backup Monitor
         </footer>
       </div>
 


### PR DESCRIPTION
## Root cause analysis

| Workflow | Error | Root cause |
|---|---|---|
| **CI (djlint)** | `H023 base.html:123` Do not use entity references | `&copy;` is an HTML entity reference; djlint H023 forbids them |
| **Docker Build** | `exit code 127` (npm run build — command not found) | `npm ci --omit=dev` skipped `tailwindcss`, `postcss` and `autoprefixer` which live in `devDependencies` — the build command was unavailable |
| **pages-build-deployment** | `Liquid syntax error: Unknown tag 'tailwind_css'` | Jekyll tries to process `docs/ROADMAP_TAILWIND_DAISYUI.md`; Django template syntax `{% tailwind_css %}` inside code blocks is interpreted as an unknown Liquid tag |

## Fixes

- `base.html`: replaced `&copy;` with the literal `©` character
- `Dockerfile`: removed `--omit=dev` flag so build-stage devDependencies are installed
- Added `.nojekyll` at repo root to disable Jekyll processing entirely

Made with [Cursor](https://cursor.com)